### PR TITLE
Add Sponsors component fetching images from database

### DIFF
--- a/components/Sponsors.js
+++ b/components/Sponsors.js
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Displays a horizontally scrolling list of sponsor logos.
+ * Sponsor data is loaded from the `/api/sponsors` endpoint which is expected
+ * to return an array of objects with the following shape:
+ * `{ id: string, name: string, image: string }` where `image` is a URL.
+ */
+export default function SponsorsBar() {
+    const [sponsors, setSponsors] = useState([]);
+
+    // Fetch sponsor data from the API route which pulls from the database
+    useEffect(() => {
+        async function loadSponsors() {
+            try {
+                const res = await fetch('/api/sponsors');
+                if (!res.ok) {
+                    throw new Error('Failed to fetch sponsors');
+                }
+                const data = await res.json();
+                setSponsors(data);
+            } catch (err) {
+                console.error('Error loading sponsors:', err);
+            }
+        }
+        loadSponsors();
+    }, []);
+
+    // Duplicate scroller items for the infinite scroll effect once sponsors load
+    useEffect(() => {
+        if (sponsors.length === 0) return;
+
+        const scrollers = document.querySelectorAll('.scroller');
+
+        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            scrollers.forEach((scroller) => {
+                scroller.setAttribute('data-animated', true);
+
+                const scrollerInner = scroller.querySelector('.scroller__inner');
+                const scrollerContent = Array.from(scrollerInner.children);
+
+                scrollerContent.forEach((item) => {
+                    const duplicatedItem = item.cloneNode(true);
+                    duplicatedItem.setAttribute('aria-hidden', true);
+                    scrollerInner.appendChild(duplicatedItem);
+                });
+            });
+        }
+    }, [sponsors]);
+
+    if (sponsors.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="scroller" data-speed="slow">
+            <div className="scroller__inner">
+                {sponsors.map((sponsor) => (
+                    <img
+                        key={sponsor.id}
+                        src={sponsor.image}
+                        alt={sponsor.name}
+                        className="scroller-item"
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "mongodb": "^5.7.0"
+  }
 }

--- a/pages/api/sponsors.js
+++ b/pages/api/sponsors.js
@@ -1,0 +1,38 @@
+import { MongoClient } from 'mongodb';
+
+let cachedClient = null;
+
+/**
+ * Retrieve sponsors from the `sponsors` collection.
+ * Each document should contain `{ name: string, image: string }`.
+ *
+ * This API route expects an environment variable `MONGODB_URI` to be
+ * defined with the connection string to the database.
+ */
+export default async function handler(req, res) {
+    try {
+        const uri = process.env.MONGODB_URI;
+        if (!uri) {
+            return res.status(500).json({ error: 'MONGODB_URI not configured' });
+        }
+
+        if (!cachedClient) {
+            const client = new MongoClient(uri);
+            cachedClient = await client.connect();
+        }
+
+        const db = cachedClient.db();
+        const sponsorDocs = await db.collection('sponsors').find({}).toArray();
+        const sponsors = sponsorDocs.map(doc => ({
+            id: doc._id?.toString() || doc.id,
+            name: doc.name,
+            image: doc.image,
+        }));
+
+        res.status(200).json(sponsors);
+    } catch (err) {
+        console.error('Failed to load sponsors', err);
+        res.status(500).json({ error: 'Failed to load sponsors' });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SponsorsBar component that loads sponsor logos from `/api/sponsors`
- create API route that retrieves sponsor data from MongoDB
- include mongodb dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc68353fe0832db17a1ae7df0d9615