### PR TITLE
Add hooks for articles and content

### DIFF
--- a/hooks/useArticles.js
+++ b/hooks/useArticles.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export default function useArticles() {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchArticles() {
+      try {
+        const res = await fetch('/api/articles');
+        if (res.ok) {
+          const data = await res.json();
+          setArticles(data);
+        } else {
+          console.warn('Failed to fetch articles:', res.status);
+        }
+      } catch (err) {
+        console.error('Failed to fetch articles:', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchArticles();
+  }, []);
+
+  return { articles, loading };
+}

--- a/hooks/useContent.js
+++ b/hooks/useContent.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+export default function useContent() {
+  const [content, setContent] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchContent() {
+      try {
+        const res = await fetch('/api/content');
+        if (res.ok) {
+          const data = await res.json();
+          setContent(data);
+        } else {
+          setError(new Error('Failed to fetch content'));
+        }
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchContent();
+  }, []);
+
+  const getNested = (keys, fallback) => {
+    let result = content;
+    for (const key of keys) {
+      if (result && typeof result === 'object' && key in result) {
+        result = result[key];
+      } else {
+        return fallback;
+      }
+    }
+    return result ?? fallback;
+  };
+
+  const getTextContent = (section, subsection, key, fallback = '') => {
+    return getNested([section, subsection, key], fallback);
+  };
+
+  const getImageContent = (section, subsection, key, fallback = '') => {
+    return getNested([section, subsection, key], fallback);
+  };
+
+  return { getTextContent, getImageContent, loading, error };
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,8 @@ import AdminLoginForm from '../components/AdminLoginForm';
 import Head from 'next/head';
 import React, { useEffect, useState } from "react";
 import Link from 'next/link';
+import useArticles from '../hooks/useArticles';
+import useContent from '../hooks/useContent';
 
 export default function Home() {
     const { articles, loading: articlesLoading } = useArticles();


### PR DESCRIPTION
## Summary
- add `useArticles` hook to load articles from `/api/articles`
- add `useContent` hook with helpers for dynamic text and images
- update home page to use new hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6e201f08832d825e1a6b913dedb6