### PR TITLE
Add Notre Comité page and user database

### DIFF
--- a/lib/userDatabase.js
+++ b/lib/userDatabase.js
@@ -1,0 +1,22 @@
+export const users = [
+  {
+    name: 'Salma Ben Ali',
+    title: 'Présidente',
+    profilePicture: 'https://via.placeholder.com/300?text=Salma',
+  },
+  {
+    name: 'Karim Ouellet',
+    title: 'Vice-président',
+    profilePicture: 'https://via.placeholder.com/300?text=Karim',
+  },
+  {
+    name: 'Nadia Gagnon',
+    title: 'Secrétaire',
+    profilePicture: 'https://via.placeholder.com/300?text=Nadia',
+  },
+  {
+    name: 'Lina Tourabi',
+    title: 'Trésorière',
+    profilePicture: 'https://via.placeholder.com/300?text=Lina',
+  },
+];

--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -1,0 +1,50 @@
+// pages/notre-comite.js
+import Navbar from "../components/Navbar";
+import Footer from '../components/Footer';
+import Head from "next/head";
+import React from "react";
+import SponsorsBar from "../components/Sponsors";
+import { users } from "../lib/userDatabase";
+
+export default function NotreComite() {
+    return (
+        <div>
+            <Head>
+                <title>Notre Comité</title>
+                <meta name="description" content="Rencontrez les membres dévoués du comité de Femme & Droit, promoteurs de féminisme et d'égalité." />
+                <meta name="keywords" content="comité, membres, féminisme, Université de Montréal, égalité" />
+            </Head>
+            <Navbar />
+            <main className="p-8">
+                <h1 className="page-title text-center mb-8">NOTRE COMITÉ</h1>
+
+                {/* Grid layout for all members except the last one (Lina Tourabi) */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+                    {users.slice(0, users.length - 1).map((member, index) => (
+                        <div key={index} className="flex flex-col items-center text-center">
+                            <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
+                            <h2 className="text-xl font-semibold">{member.name}</h2>
+                            <p className="text-gray-600">{member.title}</p>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Centered row for the last member */}
+                <div className="flex justify-center mt-8">
+                    {(() => {
+                        const member = users[users.length - 1];
+                        return (
+                            <div className="flex flex-col items-center text-center">
+                                <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
+                                <h2 className="text-xl font-semibold">{member.name}</h2>
+                                <p className="text-gray-600">{member.title}</p>
+                            </div>
+                        );
+                    })()}
+                </div>
+                <SponsorsBar />
+            </main>
+            <Footer />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add Notre Comité page with committee member grid layout and centered final member
- include user database of committee members with placeholder images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc724f72d4832dae9619411f49519f