### PR TITLE
Enable admin management of committee members

### DIFF
--- a/hooks/useUsers.js
+++ b/hooks/useUsers.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+export default function useUsers() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchUsers = async () => {
+    try {
+      const res = await fetch('/api/users');
+      if (res.ok) {
+        const data = await res.json();
+        setUsers(data);
+      } else {
+        console.warn('Failed to fetch users:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to fetch users:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const addUser = async (user) => {
+    try {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(user),
+      });
+      if (res.ok) {
+        await fetchUsers();
+      } else {
+        console.warn('Failed to add user:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to add user:', err);
+    }
+  };
+
+  const deleteUser = async (id) => {
+    try {
+      const res = await fetch(`/api/users?id=${id}`, { method: 'DELETE' });
+      if (res.ok) {
+        await fetchUsers();
+      } else {
+        console.warn('Failed to delete user:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to delete user:', err);
+    }
+  };
+
+  return { users, loading, addUser, deleteUser };
+}

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -1,4 +1,4 @@
-import { MongoClient } from 'mongodb';
+import { MongoClient, ObjectId } from 'mongodb';
 
 let cachedClient = null;
 
@@ -30,6 +30,15 @@ export default async function handler(req, res) {
       }
       const result = await collection.insertOne({ title, name, profilePicture });
       return res.status(201).json({ id: result.insertedId.toString() });
+    }
+
+    if (req.method === 'DELETE') {
+      const { id } = req.query;
+      if (!id) {
+        return res.status(400).json({ error: 'id is required' });
+      }
+      await collection.deleteOne({ _id: new ObjectId(id) });
+      return res.status(200).json({ ok: true });
     }
 
     const docs = await collection.find({}).toArray();

--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -2,11 +2,29 @@
 import Navbar from "../components/Navbar";
 import Footer from '../components/Footer';
 import Head from "next/head";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import SponsorsBar from "../components/Sponsors";
-import { users } from "../lib/userDatabase";
+import useUsers from "../hooks/useUsers";
 
 export default function NotreComite() {
+    const { users, loading, addUser, deleteUser } = useUsers();
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [name, setName] = useState("");
+    const [title, setTitle] = useState("");
+    const [profilePicture, setProfilePicture] = useState("");
+
+    useEffect(() => {
+        setIsAdmin(document.cookie.includes('admin-auth=true'));
+    }, []);
+
+    const handleAddUser = async (e) => {
+        e.preventDefault();
+        await addUser({ name, title, profilePicture });
+        setName("");
+        setTitle("");
+        setProfilePicture("");
+    };
+
     return (
         <div>
             <Head>
@@ -18,30 +36,56 @@ export default function NotreComite() {
             <main className="p-8">
                 <h1 className="page-title text-center mb-8">NOTRE COMITÉ</h1>
 
-                {/* Grid layout for all members except the last one (Lina Tourabi) */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {users.slice(0, users.length - 1).map((member, index) => (
-                        <div key={index} className="flex flex-col items-center text-center">
-                            <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
-                            <h2 className="text-xl font-semibold">{member.name}</h2>
-                            <p className="text-gray-600">{member.title}</p>
-                        </div>
-                    ))}
-                </div>
-
-                {/* Centered row for the last member */}
-                <div className="flex justify-center mt-8">
-                    {(() => {
-                        const member = users[users.length - 1];
-                        return (
-                            <div className="flex flex-col items-center text-center">
+                {loading ? (
+                    <p>Loading...</p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+                        {users.map((member) => (
+                            <div key={member.id} className="flex flex-col items-center text-center">
                                 <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
                                 <h2 className="text-xl font-semibold">{member.name}</h2>
                                 <p className="text-gray-600">{member.title}</p>
+                                {isAdmin && (
+                                    <button onClick={() => deleteUser(member.id)} className="mt-2 text-red-600">
+                                        Supprimer
+                                    </button>
+                                )}
                             </div>
-                        );
-                    })()}
-                </div>
+                        ))}
+                    </div>
+                )}
+
+                {isAdmin && (
+                    <div className="mt-12">
+                        <h2 className="text-xl font-semibold text-center mb-4">Ajouter un membre</h2>
+                        <form onSubmit={handleAddUser} className="flex flex-col space-y-2 max-w-md mx-auto">
+                            <input
+                                className="border p-2"
+                                type="text"
+                                placeholder="Nom"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                            />
+                            <input
+                                className="border p-2"
+                                type="text"
+                                placeholder="Titre"
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                            />
+                            <input
+                                className="border p-2"
+                                type="text"
+                                placeholder="URL de l'image"
+                                value={profilePicture}
+                                onChange={(e) => setProfilePicture(e.target.value)}
+                            />
+                            <button className="bg-blue-500 text-white p-2" type="submit">
+                                Ajouter
+                            </button>
+                        </form>
+                    </div>
+                )}
                 <SponsorsBar />
             </main>
             <Footer />


### PR DESCRIPTION
## Summary
- Add DELETE handling to `/api/users` for removing committee members
- Introduce `useUsers` hook to fetch and mutate member data
- Update Notre-Comite page with admin-only add/delete UI and DB-backed member list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc74bef6f8832db079ebb6bbf08f0e