### PR TITLE
Implement admin login endpoint

### DIFF
--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,13 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const { username, password } = req.body || {};
+  const adminUser = process.env.ADMIN_USER;
+  const adminPass = process.env.ADMIN_PASS;
+  if (username === adminUser && password === adminPass) {
+    res.setHeader('Set-Cookie', `admin-auth=true; Path=/; Max-Age=3600; SameSite=Strict`);
+    return res.status(200).json({ ok: true });
+  }
+  return res.status(401).json({ error: 'Invalid credentials' });
+}


### PR DESCRIPTION
## Summary
- add API route for admin login validating credentials from `ADMIN_USER` and `ADMIN_PASS`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc79ceff04832da0a9032b29b705fb