### PR TITLE
feat: add blog article admin management

### DIFF
--- a/components/ArticleForm.js
+++ b/components/ArticleForm.js
@@ -1,0 +1,221 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Form to create or edit an article.
+ * Requires a list of users to select the author from.
+ */
+export default function ArticleForm({ article, onSubmit, onCancel, users = [] }) {
+  const [formData, setFormData] = useState({
+    title: '',
+    content: '',
+    authorId: '',
+    image: '',
+    images: [],
+    date: new Date().toISOString().split('T')[0],
+  });
+
+  useEffect(() => {
+    if (article) {
+      setFormData({
+        title: article.title || '',
+        content: article.content || '',
+        authorId: article.authorId || '',
+        image: article.image || '',
+        images: article.images || [],
+        date: article.date || new Date().toISOString().split('T')[0],
+      });
+    }
+  }, [article]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleMainImage = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setFormData(prev => ({ ...prev, image: reader.result.toString() }));
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleImages = (e) => {
+    const files = Array.from(e.target.files || []);
+    Promise.all(
+      files.map(file => new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result.toString());
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      }))
+    ).then(images => {
+      setFormData(prev => ({ ...prev, images }));
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const author = users.find(u => u.id === formData.authorId);
+    onSubmit({
+      title: formData.title,
+      content: formData.content,
+      authorId: formData.authorId,
+      authorName: author?.name || '',
+      authorImage: author?.profilePicture || '',
+      image: formData.image,
+      images: formData.images,
+      date: formData.date,
+    });
+  };
+
+  const selectedAuthor = users.find(u => u.id === formData.authorId);
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h3 className="text-xl font-semibold mb-4">
+        {article ? 'Edit Article' : 'Create New Article'}
+      </h3>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Article Title *
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              placeholder="Enter article title"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Author *
+            </label>
+            <select
+              name="authorId"
+              value={formData.authorId}
+              onChange={handleChange}
+              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              required
+            >
+              <option value="">Select author</option>
+              {users.map(user => (
+                <option key={user.id} value={user.id}>{user.name}</option>
+              ))}
+            </select>
+            {selectedAuthor && (
+              <div className="flex items-center mt-2">
+                <img
+                  src={selectedAuthor.profilePicture}
+                  alt={selectedAuthor.name}
+                  className="w-8 h-8 rounded-full mr-2 object-cover"
+                />
+                <span className="text-sm text-gray-600">{selectedAuthor.name}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Main Image
+            </label>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleMainImage}
+              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            {formData.image && (
+              <img
+                src={formData.image}
+                alt="Main"
+                className="w-20 h-20 object-cover rounded mt-2"
+              />
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Additional Images
+            </label>
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleImages}
+              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+            {formData.images.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-2">
+                {formData.images.map((img, idx) => (
+                  <img key={idx} src={img} alt={`img-${idx}`} className="w-12 h-12 object-cover rounded" />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Publication Date *
+          </label>
+          <input
+            type="date"
+            name="date"
+            value={formData.date}
+            onChange={handleChange}
+            className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Article Content *
+          </label>
+          <textarea
+            name="content"
+            value={formData.content}
+            onChange={handleChange}
+            className="border border-gray-300 p-2 rounded w-full h-32 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Write your article content here..."
+            required
+          />
+          <p className="text-sm text-gray-500 mt-1">
+            {formData.content.length} characters
+          </p>
+        </div>
+
+        <div className="flex space-x-3 pt-4">
+          <button
+            type="submit"
+            className="bg-green-500 text-white px-6 py-2 rounded-lg hover:bg-green-600 transition-colors focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+          >
+            {article ? 'Update Article' : 'Create Article'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="bg-gray-500 text-white px-6 py-2 rounded-lg hover:bg-gray-600 transition-colors focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/hooks/useArticles.js
+++ b/hooks/useArticles.js
@@ -4,25 +4,55 @@ export default function useArticles() {
   const [articles, setArticles] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    async function fetchArticles() {
-      try {
-        const res = await fetch('/api/articles');
-        if (res.ok) {
-          const data = await res.json();
-          setArticles(data);
-        } else {
-          console.warn('Failed to fetch articles:', res.status);
-        }
-      } catch (err) {
-        console.error('Failed to fetch articles:', err);
-      } finally {
-        setLoading(false);
+  const fetchArticles = async () => {
+    try {
+      const res = await fetch('/api/articles');
+      if (res.ok) {
+        const data = await res.json();
+        setArticles(data);
+      } else {
+        console.warn('Failed to fetch articles:', res.status);
       }
+    } catch (err) {
+      console.error('Failed to fetch articles:', err);
+    } finally {
+      setLoading(false);
     }
+  };
 
+  useEffect(() => {
     fetchArticles();
   }, []);
 
-  return { articles, loading };
+  const addArticle = async (article) => {
+    try {
+      const res = await fetch('/api/articles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(article),
+      });
+      if (res.ok) {
+        await fetchArticles();
+      } else {
+        console.warn('Failed to add article:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to add article:', err);
+    }
+  };
+
+  const deleteArticle = async (id) => {
+    try {
+      const res = await fetch(`/api/articles?id=${id}`, { method: 'DELETE' });
+      if (res.ok) {
+        await fetchArticles();
+      } else {
+        console.warn('Failed to delete article:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to delete article:', err);
+    }
+  };
+
+  return { articles, loading, addArticle, deleteArticle };
 }

--- a/pages/api/articles.js
+++ b/pages/api/articles.js
@@ -1,0 +1,78 @@
+import { MongoClient, ObjectId } from 'mongodb';
+
+let cachedClient = null;
+
+/**
+ * API route to manage blog articles.
+ * Each article has { title, content, authorId, authorName, authorImage, image, images, date }.
+ */
+export default async function handler(req, res) {
+  try {
+    const uri = process.env.MONGODB_URI;
+    if (!uri) {
+      return res.status(500).json({ error: 'MONGODB_URI not configured' });
+    }
+
+    if (!cachedClient) {
+      const client = new MongoClient(uri);
+      cachedClient = await client.connect();
+    }
+
+    const db = cachedClient.db();
+    const collection = db.collection('articles');
+
+    if (req.method === 'POST') {
+      const { title, content, authorId, authorName, authorImage, image, images, date } = req.body;
+      if (!title || !content || !authorId || !authorName || !date) {
+        return res.status(400).json({ error: 'title, content, author and date are required' });
+      }
+      const article = {
+        title,
+        content,
+        authorId,
+        authorName,
+        authorImage: authorImage || '',
+        image: image || '',
+        images: images || [],
+        date,
+      };
+      const result = await collection.insertOne(article);
+      return res.status(201).json({ id: result.insertedId.toString() });
+    }
+
+    if (req.method === 'DELETE') {
+      const { id } = req.query;
+      if (!id) {
+        return res.status(400).json({ error: 'id is required' });
+      }
+      await collection.deleteOne({ _id: new ObjectId(id) });
+      return res.status(200).json({ ok: true });
+    }
+
+    // GET request
+    const docs = await collection.find({}).sort({ date: -1 }).toArray();
+    const articles = docs.map(doc => ({
+      id: doc._id?.toString(),
+      title: doc.title,
+      content: doc.content,
+      authorName: doc.authorName,
+      authorImage: doc.authorImage,
+      authorId: doc.authorId,
+      image: doc.image,
+      images: doc.images || [],
+      date: doc.date,
+    }));
+    res.status(200).json(articles);
+  } catch (err) {
+    console.error('Failed to handle articles', err);
+    res.status(500).json({ error: 'Failed to handle articles' });
+  }
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '8mb',
+    },
+  },
+};

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -1,0 +1,62 @@
+import Navbar from "../components/Navbar";
+import Footer from '../components/Footer';
+import Head from "next/head";
+import React, { useEffect, useState } from "react";
+import SponsorsBar from "../components/Sponsors";
+import ArticleCard from "../components/ArticleCard";
+import ArticleForm from "../components/ArticleForm";
+import useArticles from "../hooks/useArticles";
+import useUsers from "../hooks/useUsers";
+
+export default function Blog() {
+  const { articles, loading, addArticle, deleteArticle } = useArticles();
+  const { users } = useUsers();
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    setIsAdmin(document.cookie.includes('admin-auth=true'));
+  }, []);
+
+  return (
+    <div>
+      <Head>
+        <title>Blog</title>
+        <meta name="description" content="Articles et nouvelles" />
+      </Head>
+      <Navbar />
+      <main className="p-8">
+        <h1 className="page-title text-center mb-8">BLOG</h1>
+
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {articles.map((article) => (
+              <div key={article.id} className="relative">
+                <ArticleCard article={article} />
+                {isAdmin && (
+                  <button
+                    onClick={() => deleteArticle(article.id)}
+                    className="absolute top-2 right-2 bg-red-600 text-white px-2 py-1 rounded"
+                  >
+                    Supprimer
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isAdmin && (
+          <div className="mt-12 max-w-3xl mx-auto">
+            <h2 className="text-xl font-semibold text-center mb-4">Ajouter un article</h2>
+            <ArticleForm onSubmit={addArticle} onCancel={() => {}} users={users} />
+          </div>
+        )}
+
+        <SponsorsBar />
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add full blog article admin flow with create and delete capabilities
- expose add/delete operations in articles hook
- support article creation with author dropdown and image uploads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc862207c0832d9e822bb1b9be50fd