### PR TITLE
Add article detail page and API retrieval support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/pages/api/articles.js
+++ b/pages/api/articles.js
@@ -49,7 +49,27 @@ export default async function handler(req, res) {
       return res.status(200).json({ ok: true });
     }
 
-    // GET request
+    if (req.method === 'GET' && req.query.id) {
+      const { id } = req.query;
+      const doc = await collection.findOne({ _id: new ObjectId(id) });
+      if (!doc) {
+        return res.status(404).json({ error: 'Article not found' });
+      }
+      const article = {
+        id: doc._id.toString(),
+        title: doc.title,
+        content: doc.content,
+        authorName: doc.authorName,
+        authorImage: doc.authorImage,
+        authorId: doc.authorId,
+        image: doc.image,
+        images: doc.images || [],
+        date: doc.date,
+      };
+      return res.status(200).json(article);
+    }
+
+    // GET request - all articles
     const docs = await collection.find({}).sort({ date: -1 }).toArray();
     const articles = docs.map(doc => ({
       id: doc._id?.toString(),

--- a/pages/articles/[id].js
+++ b/pages/articles/[id].js
@@ -1,0 +1,89 @@
+import { MongoClient, ObjectId } from 'mongodb';
+import Navbar from '../../components/Navbar';
+import Footer from '../../components/Footer';
+import Head from 'next/head';
+
+export default function ArticlePage({ article }) {
+  if (!article) {
+    return (
+      <div>
+        <Navbar />
+        <main className="p-8">
+          <p>Article not found.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Head>
+        <title>{article.title}</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-3xl mx-auto p-8">
+        <h1 className="text-3xl font-bold mb-4">{article.title}</h1>
+        <div className="flex items-center mb-4">
+          {article.authorImage && (
+            <img
+              src={article.authorImage}
+              alt={article.authorName}
+              className="w-10 h-10 rounded-full mr-2 object-cover"
+            />
+          )}
+          <span className="text-sm text-gray-600">{article.authorName}</span>
+          <span className="ml-2 text-sm text-gray-500">{article.date}</span>
+        </div>
+        {article.image && (
+          <img
+            src={article.image}
+            alt={article.title}
+            className="mb-4 w-full h-auto object-cover"
+          />
+        )}
+        <p className="whitespace-pre-wrap">{article.content}</p>
+        {article.images && article.images.length > 0 && (
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+            {article.images.map((img, idx) => (
+              <img
+                key={idx}
+                src={img}
+                alt={`${article.title}-${idx}`}
+                className="w-full h-auto object-cover rounded"
+              />
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export async function getServerSideProps({ params }) {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    return { props: { article: null } };
+  }
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db();
+  const doc = await db.collection('articles').findOne({ _id: new ObjectId(params.id) });
+  await client.close();
+  if (!doc) {
+    return { props: { article: null } };
+  }
+  const article = {
+    id: doc._id.toString(),
+    title: doc.title,
+    content: doc.content,
+    authorName: doc.authorName,
+    authorImage: doc.authorImage,
+    authorId: doc.authorId,
+    image: doc.image,
+    images: doc.images || [],
+    date: doc.date,
+  };
+  return { props: { article } };
+}


### PR DESCRIPTION
## Summary
- extend articles API with support for fetching a single article by id
- add dynamic article detail page that pulls article data from MongoDB
- ignore build artifacts and node modules

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc8955c1f0832d8dbcaa5d3e8cbf59