### PR TITLE
Add events calendar page with basic event API

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -37,8 +37,8 @@ export default function Navbar() {
                     </Link>
                 </li>
                 <li>
-                    <Link href="/venir">
-                        <span className={`nav-link text-black ${isActive('/venir') ? 'underline font-bold' : ''}`}>Événements</span>
+                    <Link href="/evenements">
+                        <span className={`nav-link text-black ${isActive('/evenements') ? 'underline font-bold' : ''}`}>Événements</span>
                     </Link>
                 </li>
                 <li>

--- a/hooks/useEvents.js
+++ b/hooks/useEvents.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+export default function useEvents() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchEvents = async () => {
+    try {
+      const res = await fetch('/api/events');
+      if (res.ok) {
+        const data = await res.json();
+        setEvents(data);
+      } else {
+        console.warn('Failed to fetch events:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to fetch events:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents();
+  }, []);
+
+  const addEvent = async (event) => {
+    try {
+      const res = await fetch('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(event),
+      });
+      if (res.ok) {
+        await fetchEvents();
+      } else {
+        console.warn('Failed to add event:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to add event:', err);
+    }
+  };
+
+  return { events, loading, addEvent };
+}

--- a/lib/eventDatabase.js
+++ b/lib/eventDatabase.js
@@ -1,0 +1,1 @@
+export const events = [];

--- a/pages/api/events.js
+++ b/pages/api/events.js
@@ -1,0 +1,14 @@
+import { events } from '../../lib/eventDatabase';
+
+export default function handler(req, res) {
+  if (req.method === 'POST') {
+    const { title, bio, date } = req.body;
+    if (!title || !bio || !date) {
+      return res.status(400).json({ error: 'title, bio and date are required' });
+    }
+    events.push({ id: Date.now().toString(), title, bio, date });
+    return res.status(201).json({ ok: true });
+  }
+
+  res.status(200).json(events);
+}

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -1,0 +1,134 @@
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
+import useEvents from '../hooks/useEvents';
+
+export default function Evenements() {
+  const { events, loading, addEvent } = useEvents();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [title, setTitle] = useState('');
+  const [bio, setBio] = useState('');
+  const [date, setDate] = useState('');
+
+  useEffect(() => {
+    setIsAdmin(document.cookie.includes('admin-auth=true'));
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!title || !bio || !date) return;
+    await addEvent({ title, bio, date });
+    setTitle('');
+    setBio('');
+    setDate('');
+  };
+
+  const today = new Date();
+  const [month] = useState(today.getMonth());
+  const [year] = useState(today.getFullYear());
+
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const eventsByDate = events.reduce((acc, ev) => {
+    acc[ev.date] = acc[ev.date] || [];
+    acc[ev.date].push(ev);
+    return acc;
+  }, {});
+
+  const weeks = [];
+  let day = 1 - firstDay;
+  while (day <= daysInMonth) {
+    const week = [];
+    for (let i = 0; i < 7; i++) {
+      if (day > 0 && day <= daysInMonth) {
+        const dateStr = new Date(year, month, day).toISOString().slice(0, 10);
+        week.push({ day, dateStr, events: eventsByDate[dateStr] || [] });
+      } else {
+        week.push(null);
+      }
+      day++;
+    }
+    weeks.push(week);
+  }
+
+  return (
+    <div>
+      <Head>
+        <title>Événements</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-4xl mx-auto p-4">
+        <h1 className="text-3xl text-center mb-4">Événements</h1>
+        {isAdmin && (
+          <form onSubmit={handleSubmit} className="mb-8 space-y-2">
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Titre"
+              className="border p-2 w-full"
+            />
+            <textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              placeholder="Bio"
+              className="border p-2 w-full"
+            />
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="border p-2 w-full"
+            />
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+            >
+              Ajouter
+            </button>
+          </form>
+        )}
+
+        {loading ? (
+          <div>Loading...</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr>
+                  {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+                    <th key={d} className="border p-2">
+                      {d}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {weeks.map((week, i) => (
+                  <tr key={i}>
+                    {week.map((dayObj, idx) => (
+                      <td key={idx} className="border h-24 align-top p-1">
+                        {dayObj && (
+                          <div>
+                            <div className="font-bold">{dayObj.day}</div>
+                            {dayObj.events.map((ev) => (
+                              <div key={ev.id} className="text-xs mt-1">
+                                {ev.title}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory event database and API endpoint to store events
- create events hook and calendar page with admin form
- update navbar to link to events page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc904d3108832d88fe74dfef4bb6f2