### PR TITLE
Add contact page and email sending API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_SECURE=false
+EMAIL_USER=example@example.com
+EMAIL_PASS=supersecret
+EMAIL_FROM="Site Contact <example@example.com>"
+EMAIL_TO=owner@example.com

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "mongodb": "^5.8.0"
+    "mongodb": "^5.8.0",
+    "nodemailer": "^6.9.11"
   }
 }

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -1,0 +1,39 @@
+import nodemailer from 'nodemailer';
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        res.status(405).json({ message: 'Method Not Allowed' });
+        return;
+    }
+
+    const { nom, email, objet, message } = req.body || {};
+
+    if (!nom || !email || !objet || !message) {
+        res.status(400).json({ message: 'Missing required fields' });
+        return;
+    }
+
+    const transporter = nodemailer.createTransport({
+        host: process.env.EMAIL_HOST,
+        port: parseInt(process.env.EMAIL_PORT, 10) || 587,
+        secure: process.env.EMAIL_SECURE === 'true',
+        auth: {
+            user: process.env.EMAIL_USER,
+            pass: process.env.EMAIL_PASS
+        }
+    });
+
+    try {
+        await transporter.sendMail({
+            from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
+            to: process.env.EMAIL_TO || process.env.EMAIL_USER,
+            subject: `Contact Form: ${objet}`,
+            text: `Nom: ${nom}\nEmail: ${email}\n\n${message}`,
+            replyTo: email
+        });
+        res.status(200).json({ message: 'Email sent successfully' });
+    } catch (error) {
+        console.error('Error sending email:', error);
+        res.status(500).json({ message: 'Failed to send email' });
+    }
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,0 +1,13 @@
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import ContactCard from '../components/ContactCard';
+
+export default function ContactPage() {
+    return (
+        <div>
+            <Navbar />
+            <ContactCard />
+            <Footer />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add contact page wrapping existing contact form component
- enable email delivery via new `/api/send-email` endpoint using Nodemailer
- document required environment variables for SMTP configuration

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden fetching nodemailer)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9237c254832d812cf7191fe7868f