### PR TITLE
Improve article card and article image sizing

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -25,16 +25,18 @@ export default function ArticleCard({ article = {}, isLarge = false }) {
 
     return (
         <Link href={`/articles/${id}`}>
-            <div className={`rounded overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-200 ${isLarge ? 'md:flex' : ''} cursor-pointer`}>
+            <div
+                className={`bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-transform duration-200 cursor-pointer hover:scale-[1.02] ${isLarge ? 'md:flex' : ''}`}
+            >
                 <img
                     src={imageSrc}
                     alt={title}
-                    className={`${isLarge ? 'w-full md:w-1/3 h-48 object-cover' : 'w-full h-48 object-cover'}`}
+                    className={`${isLarge ? 'md:w-1/3 md:h-full' : ''} w-full h-40 object-cover`}
                 />
-                <div className="p-4">
+                <div className={`p-4 flex flex-col justify-between ${isLarge ? 'md:w-2/3' : ''}`}>
                     <h3 className="text-xl font-bold mb-2">{title}</h3>
                     <p className="text-gray-700 mb-4">{excerpt}</p>
-                    <div className="flex items-center">
+                    <div className="flex items-center mt-auto">
                         <img
                             src={authorImage}
                             alt={authorName}

--- a/pages/articles/[id].js
+++ b/pages/articles/[id].js
@@ -39,7 +39,7 @@ export default function ArticlePage({ article }) {
           <img
             src={article.image}
             alt={article.title}
-            className="mb-4 w-full h-auto object-cover"
+            className="mb-4 w-full max-h-96 object-cover rounded"
           />
         )}
         <p className="whitespace-pre-wrap">{article.content}</p>
@@ -50,7 +50,7 @@ export default function ArticlePage({ article }) {
                 key={idx}
                 src={img}
                 alt={`${article.title}-${idx}`}
-                className="w-full h-auto object-cover rounded"
+                className="w-full h-48 object-cover rounded"
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Revamp article card styling with white background, subtle hover effects, and reduced image height for consistent previews
- Limit main article and gallery image dimensions for more readable article pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9daf27b8832d95dcce7fdf639321