### PR TITLE
Refine article card layout

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -9,40 +9,38 @@ import Link from 'next/link';
  *      title,
  *      content/body,
  *      image/imageUrl/coverImage,
- *      author: { name, profilePic } or authorName/authorImage
+ *      author: { name, profilePic } or authorName/authorImage,
+ *      date
  *    }
- *  - isLarge: optional boolean to adjust layout
  */
-export default function ArticleCard({ article = {}, isLarge = false }) {
+export default function ArticleCard({ article = {} }) {
     const id = article._id || article.id;
     const imageSrc = article.image || article.imageUrl || article.coverImage || '/images/default-article.jpg';
     const title = article.title || 'Untitled';
     const content = article.content || article.body || '';
     const authorName = (article.author && article.author.name) || article.authorName || 'Unknown';
     const authorImage = (article.author && article.author.profilePic) || article.authorImage || '/images/default-avatar.png';
+    const date = article.date || '';
 
-    const excerpt = content.length > 200 ? `${content.slice(0, 200)}...` : content;
+    const excerpt = content.length > 100 ? `${content.slice(0, 100)}...` : content;
 
     return (
         <Link href={`/articles/${id}`}>
-            <div
-                className={`bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-transform duration-200 cursor-pointer hover:scale-[1.02] ${isLarge ? 'md:flex' : ''}`}
-            >
-                <img
-                    src={imageSrc}
-                    alt={title}
-                    className={`${isLarge ? 'md:w-1/3 md:h-full' : ''} w-full h-40 object-cover`}
-                />
-                <div className={`p-4 flex flex-col justify-between ${isLarge ? 'md:w-2/3' : ''}`}>
-                    <h3 className="text-xl font-bold mb-2">{title}</h3>
-                    <p className="text-gray-700 mb-4">{excerpt}</p>
-                    <div className="flex items-center mt-auto">
-                        <img
-                            src={authorImage}
-                            alt={authorName}
-                            className="w-8 h-8 rounded-full mr-2 object-cover"
-                        />
-                        <span className="text-sm text-gray-600">{authorName}</span>
+            <div className="max-w-sm mx-auto bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-transform duration-200 cursor-pointer hover:scale-[1.02]">
+                <img src={imageSrc} alt={title} className="w-full h-40 object-cover" />
+                <div className="p-4">
+                    <h3 className="text-lg font-semibold mb-2">{title}</h3>
+                    <p className="text-gray-700 text-sm mb-4">{excerpt}</p>
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center">
+                            <img
+                                src={authorImage}
+                                alt={authorName}
+                                className="w-8 h-8 rounded-full mr-2 object-cover"
+                            />
+                            <span className="text-sm text-gray-600">{authorName}</span>
+                        </div>
+                        {date && <span className="text-xs text-gray-500">{date}</span>}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- simplify ArticleCard to a compact card with image, title, snippet, author info, and date
- shorten article preview to first 100 characters

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68bca924726c832d96141935188081ef