### PR TITLE
Handle missing article fields in server-side props

### DIFF
--- a/pages/articles/[id].js
+++ b/pages/articles/[id].js
@@ -64,12 +64,12 @@ export async function getServerSideProps({ params }) {
   }
   const article = {
     id: doc._id.toString(),
-    title: doc.title,
-    content: doc.content,
-    author: doc.author,
-    authorImage: doc.authorImage,
-    image: doc.image,
-    date: doc.date,
+    title: doc.title ?? '',
+    content: doc.content ?? '',
+    author: doc.author ?? null,
+    authorImage: doc.authorImage ?? null,
+    image: doc.image ?? null,
+    date: doc.date ?? null,
   };
   return { props: { article } };
 }


### PR DESCRIPTION
## Summary
- ensure article fields use fallback values so getServerSideProps returns serializable data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)
- `npm install next react react-dom` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bcd99b195c832da4fac09c19490714