### PR TITLE
Add admin-managed Guide des Commanditaires page

### DIFF
--- a/hooks/useSponsors.js
+++ b/hooks/useSponsors.js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+export default function useSponsors() {
+    const [sponsors, setSponsors] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    const fetchSponsors = async () => {
+        try {
+            const res = await fetch('/api/sponsors');
+            if (res.ok) {
+                const data = await res.json();
+                setSponsors(data);
+            } else {
+                console.warn('Failed to fetch sponsors:', res.status);
+            }
+        } catch (err) {
+            console.error('Failed to fetch sponsors:', err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchSponsors();
+    }, []);
+
+    const addSponsor = async (sponsor) => {
+        try {
+            const res = await fetch('/api/sponsors', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(sponsor),
+            });
+            if (res.ok) {
+                await fetchSponsors();
+            } else {
+                console.warn('Failed to add sponsor:', res.status);
+            }
+        } catch (err) {
+            console.error('Failed to add sponsor:', err);
+        }
+    };
+
+    const deleteSponsor = async (id) => {
+        try {
+            const res = await fetch(`/api/sponsors?id=${id}`, { method: 'DELETE' });
+            if (res.ok) {
+                await fetchSponsors();
+            } else {
+                console.warn('Failed to delete sponsor:', res.status);
+            }
+        } catch (err) {
+            console.error('Failed to delete sponsor:', err);
+        }
+    };
+
+    return { sponsors, loading, addSponsor, deleteSponsor };
+}
+

--- a/pages/guide.js
+++ b/pages/guide.js
@@ -1,0 +1,145 @@
+import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import Head from 'next/head';
+import AdminLoginForm from '../components/AdminLoginForm';
+import useSponsors from '../hooks/useSponsors';
+
+export default function GuidePage() {
+    const { sponsors, loading, addSponsor, deleteSponsor } = useSponsors();
+    const [selectedSponsor, setSelectedSponsor] = useState(null);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [name, setName] = useState('');
+    const [image, setImage] = useState('');
+
+    useEffect(() => {
+        setIsAdmin(document.cookie.includes('admin-auth=true'));
+    }, []);
+
+    const openModal = (index) => {
+        setSelectedSponsor(sponsors[index]);
+        setCurrentIndex(index);
+    };
+
+    const closeModal = () => {
+        setSelectedSponsor(null);
+        setCurrentIndex(0);
+    };
+
+    const nextImage = () => {
+        if (sponsors.length === 0) return;
+        const nextIndex = (currentIndex + 1) % sponsors.length;
+        setSelectedSponsor(sponsors[nextIndex]);
+        setCurrentIndex(nextIndex);
+    };
+
+    const prevImage = () => {
+        if (sponsors.length === 0) return;
+        const prevIndex = (currentIndex - 1 + sponsors.length) % sponsors.length;
+        setSelectedSponsor(sponsors[prevIndex]);
+        setCurrentIndex(prevIndex);
+    };
+
+    const handleAdd = async (e) => {
+        e.preventDefault();
+        if (!name || !image) return;
+        await addSponsor({ name, image });
+        setName('');
+        setImage('');
+    };
+
+    return (
+        <div>
+            <Head>
+                <title>Guide des Commanditaires</title>
+                <meta
+                    name="description"
+                    content="Découvrez notre guide des commanditaires avec toutes les images en aperçu."
+                />
+                <meta
+                    name="keywords"
+                    content="commanditaires, guide, partenaires, photos, féminisme, Université de Montréal"
+                />
+            </Head>
+            <Navbar />
+            <main className="p-8">
+                <h1 className="page-title text-center mb-8">Guide des Commanditaires</h1>
+                {isAdmin && (
+                    <form onSubmit={handleAdd} className="mb-8 space-y-2">
+                        <input
+                            className="border p-2 w-full"
+                            placeholder="Nom"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                        <input
+                            className="border p-2 w-full"
+                            placeholder="URL de l'image"
+                            value={image}
+                            onChange={(e) => setImage(e.target.value)}
+                        />
+                        <button
+                            type="submit"
+                            className="bg-blue-600 text-white px-4 py-2 rounded"
+                        >
+                            Ajouter
+                        </button>
+                    </form>
+                )}
+                <div className="sponsor-gallery">
+                    {loading ? (
+                        <p>Loading...</p>
+                    ) : (
+                        sponsors.map((sponsor, index) => (
+                            <div key={sponsor.id} className="relative inline-block">
+                                <img
+                                    src={sponsor.image}
+                                    alt={sponsor.name}
+                                    className="sponsor-image rounded-lg cursor-pointer hover:shadow-lg"
+                                    onClick={() => openModal(index)}
+                                />
+                                {isAdmin && (
+                                    <button
+                                        onClick={() => deleteSponsor(sponsor.id)}
+                                        className="absolute top-2 right-2 bg-red-500 text-white px-2 py-1 rounded"
+                                    >
+                                        &times;
+                                    </button>
+                                )}
+                            </div>
+                        ))
+                    )}
+                </div>
+                {!isAdmin && (
+                    <div className="my-8 text-center">
+                        <h2 className="text-xl font-bold mb-2">Admin Login</h2>
+                        <AdminLoginForm />
+                    </div>
+                )}
+                {selectedSponsor && (
+                    <div className="modal">
+                        <div className="modal-content">
+                            <img
+                                src={selectedSponsor.image}
+                                alt={selectedSponsor.name}
+                                className="modal-image"
+                            />
+                            <button className="close" onClick={closeModal}>
+                                &times;
+                            </button>
+                            <button className="prev" onClick={prevImage}>
+                                &lt;
+                            </button>
+                            <button className="next" onClick={nextImage}>
+                                &gt;
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </main>
+            <Footer />
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- create Guide des Commanditaires page displaying sponsor pages
- allow admins to add and remove guide pages via new hook
- extend sponsors API with POST and DELETE endpoints for admin management

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfa1038f8832d89d973f42d838444