### PR TITLE
Enable uploading sponsor images

### DIFF
--- a/components/Sponsors.js
+++ b/components/Sponsors.js
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 
 /**
  * Displays a horizontally scrolling list of sponsor logos.
- * Sponsor data is loaded from the `/api/sponsors` endpoint which is expected
- * to return an array of objects with the following shape:
- * `{ id: string, name: string, image: string }` where `image` is a URL.
+ * Sponsor data is loaded from the `/api/sponsors` endpoint which returns an
+ * array of objects shaped like `{ id: string, image: string }` where `image`
+ * is a base64-encoded data URL.
  */
 export default function SponsorsBar() {
     const [sponsors, setSponsors] = useState([]);
@@ -59,7 +59,7 @@ export default function SponsorsBar() {
                     <img
                         key={sponsor.id}
                         src={sponsor.image}
-                        alt={sponsor.name}
+                        alt="Sponsor"
                         className="scroller-item"
                     />
                 ))}

--- a/pages/api/sponsors.js
+++ b/pages/api/sponsors.js
@@ -4,7 +4,8 @@ let cachedClient = null;
 
 /**
  * Retrieve sponsors from the `sponsors` collection.
- * Each document should contain `{ name: string, image: string }`.
+ * Each document should contain `{ image: string }` where the image is a
+ * base64-encoded data URL.
  *
  * This API route expects an environment variable `MONGODB_URI` to be
  * defined with the connection string to the database.
@@ -25,11 +26,11 @@ export default async function handler(req, res) {
         const collection = db.collection('sponsors');
 
         if (req.method === 'POST') {
-            const { name, image } = req.body || {};
-            if (!name || !image) {
-                return res.status(400).json({ error: 'name and image are required' });
+            const { image } = req.body || {};
+            if (!image) {
+                return res.status(400).json({ error: 'image is required' });
             }
-            const result = await collection.insertOne({ name, image });
+            const result = await collection.insertOne({ image });
             return res.status(201).json({ id: result.insertedId.toString() });
         }
 
@@ -45,7 +46,6 @@ export default async function handler(req, res) {
         const sponsorDocs = await collection.find({}).toArray();
         const sponsors = sponsorDocs.map(doc => ({
             id: doc._id?.toString() || doc.id,
-            name: doc.name,
             image: doc.image,
         }));
 

--- a/pages/guide.js
+++ b/pages/guide.js
@@ -10,7 +10,6 @@ export default function GuidePage() {
     const [selectedSponsor, setSelectedSponsor] = useState(null);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isAdmin, setIsAdmin] = useState(false);
-    const [name, setName] = useState('');
     const [image, setImage] = useState('');
 
     useEffect(() => {
@@ -41,11 +40,20 @@ export default function GuidePage() {
         setCurrentIndex(prevIndex);
     };
 
+    const handleFileChange = (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            setImage(reader.result);
+        };
+        reader.readAsDataURL(file);
+    };
+
     const handleAdd = async (e) => {
         e.preventDefault();
-        if (!name || !image) return;
-        await addSponsor({ name, image });
-        setName('');
+        if (!image) return;
+        await addSponsor({ image });
         setImage('');
     };
 
@@ -68,16 +76,10 @@ export default function GuidePage() {
                 {isAdmin && (
                     <form onSubmit={handleAdd} className="mb-8 space-y-2">
                         <input
+                            type="file"
+                            accept="image/*"
                             className="border p-2 w-full"
-                            placeholder="Nom"
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                        />
-                        <input
-                            className="border p-2 w-full"
-                            placeholder="URL de l'image"
-                            value={image}
-                            onChange={(e) => setImage(e.target.value)}
+                            onChange={handleFileChange}
                         />
                         <button
                             type="submit"
@@ -95,7 +97,7 @@ export default function GuidePage() {
                             <div key={sponsor.id} className="relative inline-block">
                                 <img
                                     src={sponsor.image}
-                                    alt={sponsor.name}
+                                    alt="Sponsor"
                                     className="sponsor-image rounded-lg cursor-pointer hover:shadow-lg"
                                     onClick={() => openModal(index)}
                                 />
@@ -122,7 +124,7 @@ export default function GuidePage() {
                         <div className="modal-content">
                             <img
                                 src={selectedSponsor.image}
-                                alt={selectedSponsor.name}
+                                alt="Sponsor"
                                 className="modal-image"
                             />
                             <button className="close" onClick={closeModal}>


### PR DESCRIPTION
## Summary
- Allow admins to upload sponsor images directly from their computer on the Guide des Commanditaires page
- Store uploaded sponsor images as base64 in the database with no name requirement
- Update sponsors display components to accommodate nameless images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfd04b9a8832d9f5dc6d6526039d1