### PR TITLE
feat: add admin login link to footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,10 +1,14 @@
 import React from 'react';
+import Link from 'next/link';
 
 export default function Footer() {
     return (
         <footer className="footer">
             <div className="footer-content">
                 <span>©2024 Comité Femmes et Droit UdeM</span>
+                <Link href="/admin" className="admin-login">
+                    Admin Login
+                </Link>
             </div>
         </footer>
     );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -511,10 +511,16 @@ button[type="submit"]:hover {
 }
 
 .footer-content {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 30rem;
+    width: 100%;
+}
+
+.admin-login {
+    position: absolute;
+    right: 0;
 }
 
 .instagram-icon {
@@ -800,8 +806,7 @@ button[type="submit"]:hover {
     }
 
     .footer-content {
-        flex-direction: column;
-        gap: 1rem;
+        flex-direction: row;
     }
 
     nav {


### PR DESCRIPTION
## Summary
- restore admin login link in footer with right alignment
- style footer for centered copyright

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd0036ec28832d91899bbc60ce7223