### PR TITLE
feat: add footer login form

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,15 +1,52 @@
-import React from 'react';
-import Link from 'next/link';
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 
 export default function Footer() {
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const router = useRouter();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError('');
+        const res = await fetch('/api/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+        });
+        if (res.ok) {
+            router.push('/admin');
+        } else {
+            setError('Invalid credentials');
+        }
+    };
+
     return (
         <footer className="footer">
-            <div className="footer-content">
+            <div className="footer-content flex flex-col sm:flex-row sm:items-center sm:justify-between">
                 <span>©2024 Comité Femmes et Droit UdeM</span>
-                <Link href="/admin" className="admin-login">
-                    Admin Login
-                </Link>
+                <form onSubmit={handleSubmit} className="mt-2 sm:mt-0 flex space-x-2">
+                    <input
+                        className="border p-1"
+                        type="text"
+                        placeholder="Username"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                    />
+                    <input
+                        className="border p-1"
+                        type="password"
+                        placeholder="Password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                    />
+                    <button className="bg-blue-500 text-white px-3 py-1" type="submit">
+                        Login
+                    </button>
+                </form>
             </div>
+            {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
         </footer>
     );
 }


### PR DESCRIPTION
## Summary
- embed username/password inputs with login button directly in footer
- add inline login submission logic for admin access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0312ecbc832d91b97b773c7917aa