### PR TITLE
Redesign article card component

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -1,13 +1,13 @@
 import Link from 'next/link';
 
-// Normalizes varying article structures into a single format
-function normalizeArticle(article = {}) {
+// Format raw article data into a unified shape
+function formatArticle(raw = {}) {
   const {
     _id,
     id,
     title = 'Untitled',
-    content,
     body,
+    content,
     image,
     imageUrl,
     coverImage,
@@ -17,74 +17,52 @@ function normalizeArticle(article = {}) {
     date = '',
     category,
     tag,
-  } = article;
+  } = raw;
 
   return {
     id: _id || id,
     title,
-    body: content || body || '',
+    body: body || content || '',
     image: image || imageUrl || coverImage || 'https://placehold.co/600x400',
-    authorName: author.name || authorName || 'Unknown',
-    authorImage: author.profilePic || authorImage || 'https://placehold.co/40',
+    author: {
+      name: author.name || authorName || 'Unknown',
+      image: author.profilePic || authorImage || 'https://placehold.co/48',
+    },
     date,
     category: category || tag || '',
   };
 }
 
-// Displays an article preview with flexible layout
-export default function ArticleCard({ article = {}, isLarge = false }) {
-  const normalized = normalizeArticle(article);
-  const excerptLength = isLarge ? 160 : 100;
-  const excerpt =
-    normalized.body.length > excerptLength
-      ? `${normalized.body.slice(0, excerptLength)}...`
-      : normalized.body;
-
-  const containerClass = isLarge
-    ? 'md:flex-row md:h-72'
-    : 'flex-col max-w-sm';
-  const imageClass = isLarge ? 'md:w-1/2 h-72' : 'w-full h-40';
-  const paddingClass = isLarge ? 'p-6' : 'p-4';
-  const titleClass = isLarge ? 'text-xl' : 'text-lg';
-  const excerptClass = `text-gray-600 text-sm mb-4 ${isLarge ? 'flex-1' : ''}`;
-  const authorImageClass = isLarge ? 'w-10 h-10' : 'w-8 h-8';
+// Compact article preview card
+export default function ArticleCard({ article = {} }) {
+  const a = formatArticle(article);
+  const excerpt = a.body.length > 80 ? `${a.body.slice(0, 80)}...` : a.body;
 
   return (
-    <Link href={`/articles/${normalized.id}`}>
-      <article
-        className={`flex ${containerClass} bg-white rounded-xl shadow-md overflow-hidden cursor-pointer transition-transform duration-200 hover:shadow-lg hover:-translate-y-1`}
-      >
-        <div className={`relative ${imageClass} flex-shrink-0`}>
-          <img
-            src={normalized.image}
-            alt={normalized.title}
-            className="absolute inset-0 w-full h-full object-cover"
-          />
-          {normalized.category && (
-            <span className="absolute top-2 left-2 bg-blue-600 text-white text-xs font-medium px-3 py-1 rounded-full">
-              {normalized.category}
+    <Link href={`/articles/${a.id}`}>
+      <article className="max-w-xs overflow-hidden rounded-lg bg-white shadow transition-shadow duration-200 hover:shadow-lg">
+        <div className="relative h-36 w-full">
+          <img src={a.image} alt={a.title} className="h-full w-full object-cover" />
+          {a.category && (
+            <span className="absolute left-2 top-2 rounded-full bg-blue-600 px-2 py-0.5 text-[10px] font-medium text-white">
+              {a.category}
             </span>
           )}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
         </div>
-
-        <div className={`${paddingClass} flex flex-col flex-1`}>
-          <h3 className={`${titleClass} font-semibold mb-3`}>{normalized.title}</h3>
-          <p className={excerptClass}>{excerpt}</p>
-          <div className="flex items-center mt-auto">
+        <div className="space-y-2 p-4">
+          <h3 className="text-sm font-semibold leading-snug">{a.title}</h3>
+          <p className="text-xs text-gray-600">{excerpt}</p>
+          <div className="flex items-center border-t pt-2 text-xs text-gray-500">
             <img
-              src={normalized.authorImage}
-              alt={normalized.authorName}
-              className={`${authorImageClass} rounded-full mr-3 object-cover`}
+              src={a.author.image}
+              alt={a.author.name}
+              className="mr-2 h-6 w-6 rounded-full object-cover"
             />
-            <div className="text-sm">
-              <p className="text-gray-900 leading-none">{normalized.authorName}</p>
-              {normalized.date && <p className="text-gray-500 text-xs">{normalized.date}</p>}
-            </div>
+            <span className="mr-auto">{a.author.name}</span>
+            {a.date && <span>{a.date}</span>}
           </div>
         </div>
       </article>
     </Link>
   );
 }
-

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -41,7 +41,7 @@ export default function Blog() {
             <Navbar/>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 {posts.map((article) => (
-                    <ArticleCard key={article.id || article._id} article={article} isLarge={true}/>
+                    <ArticleCard key={article.id || article._id} article={article} />
                 ))}
             </div>
             {!isAdmin ? (

--- a/pages/index.js
+++ b/pages/index.js
@@ -70,7 +70,7 @@ export default function Home() {
                     <h2 className="text-2xl text-center mt-8 mb-4">{recentArticlesTitle}</h2>
                     <div className="article-cards-container">
                         {topThreeArticles.map((article) => (
-                            <ArticleCard key={article._id || article.id} article={article} isLarge={false} />
+                            <ArticleCard key={article._id || article.id} article={article} />
                         ))}
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- Rebuild ArticleCard into a compact, modern preview card
- Drop `isLarge` prop and update blog and home pages to use new card

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1f776d278832d8046691ca2ed21c7