### PR TITLE
Remove HeroUI Calendar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@heroui/react": "latest",
     "@internationalized/date": "latest",
     "mongodb": "^5.8.0",
     "nodemailer": "^6.9.11"

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -3,8 +3,6 @@ import Footer from '../components/Footer';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import useEvents from '../hooks/useEvents';
-import { Calendar } from '@heroui/react';
-import { parseDate } from '@internationalized/date';
 
 export default function Evenements() {
   const { events, loading, addEvent } = useEvents();
@@ -70,12 +68,12 @@ export default function Evenements() {
         ) : (
           <div>
             <div className="flex justify-center my-8">
-              <div className="transform scale-150">
-                <Calendar
-                  aria-label="Calendrier des événements"
-                  defaultValue={parseDate(todayStr)}
-                />
-              </div>
+              <input
+                type="date"
+                value={todayStr}
+                readOnly
+                className="border p-2"
+              />
             </div>
             <div className="mt-8 space-y-4">
               {events.map((ev) => (


### PR DESCRIPTION
## Summary
- Replace HeroUI Calendar with native date input to avoid missing `@heroui/react`
- Drop `@heroui/react` from package.json dependencies

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fadba828832db976610bc9fa7ab1