### PR TITLE
Replace HeroUI calendar with Mantine Calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@internationalized/date": "latest",
-    "@heroui/react": "latest",
+    "@mantine/core": "latest",
+    "@mantine/hooks": "latest",
+    "@mantine/dates": "latest",
     "mongodb": "^5.8.0",
     "nodemailer": "^6.9.11"
   }

--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -3,7 +3,7 @@ import Footer from '../components/Footer';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import useEvents from '../hooks/useEvents';
-import { Calendar } from '@heroui/react';
+import { Calendar } from '@mantine/dates';
 
 export default function Evenements() {
   const { events, loading, addEvent } = useEvents();


### PR DESCRIPTION
## Summary
- swap HeroUI calendar for Mantine's calendar component
- remove HeroUI dependencies and add Mantine packages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@mantine%2fcore)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d3af82e4832db0d29943e8d6799e