### PR TITLE
Remove admin dashboard redirect

### DIFF
--- a/components/AdminLoginForm.js
+++ b/components/AdminLoginForm.js
@@ -16,7 +16,7 @@ export default function AdminLoginForm() {
             body: JSON.stringify({ username, password })
         });
         if (res.ok) {
-            router.push("/admin");
+            router.reload();
         } else {
             setError("Invalid credentials");
         }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -16,7 +16,7 @@ export default function Footer() {
             body: JSON.stringify({ username, password })
         });
         if (res.ok) {
-            router.push('/admin');
+            router.reload();
         } else {
             setError('Invalid credentials');
         }

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -6,7 +6,6 @@ import Footer from '../components/Footer';
 import SponsorsBar from '../components/Sponsors';
 import AdminLoginForm from '../components/AdminLoginForm';
 import Head from 'next/head';
-import Link from 'next/link';
 
 export default function Blog() {
     const { articles } = useArticles();
@@ -44,14 +43,10 @@ export default function Blog() {
                     <ArticleCard key={article.id || article._id} article={article} />
                 ))}
             </div>
-            {!isAdmin ? (
+            {!isAdmin && (
                 <div className="my-8">
                     <h2 className="text-xl font-bold mb-2">Admin Login</h2>
                     <AdminLoginForm />
-                </div>
-            ) : (
-                <div className="my-8 text-center">
-                    <Link href="/admin" className="bg-blue-500 text-white px-4 py-2 rounded">Go to Admin Dashboard</Link>
                 </div>
             )}
             <SponsorsBar />


### PR DESCRIPTION
## Summary
- Reload current page after successful admin login instead of redirecting to a non-existent admin page
- Drop admin dashboard link from blog page; show login form only when not authenticated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d946d1a4832da4b452b1766653ee