### PR TITLE
feat: allow admin to edit home banner

### DIFF
--- a/components/HeroBannerEditor.js
+++ b/components/HeroBannerEditor.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export default function HeroBannerEditor({ currentImage, updateContent }) {
+  const [image, setImage] = useState('');
+  const [preview, setPreview] = useState(currentImage);
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImage(reader.result);
+      setPreview(reader.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!image) return;
+    await updateContent('home', 'hero', 'hero_banner', image);
+    setImage('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 space-y-2">
+      {preview && (
+        <img src={preview} alt="Banner preview" className="w-full max-w-xl" />
+      )}
+      <input type="file" accept="image/*" onChange={handleFileChange} />
+      <button
+        type="submit"
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        Update Banner
+      </button>
+    </form>
+  );
+}

--- a/hooks/useContent.js
+++ b/hooks/useContent.js
@@ -45,5 +45,23 @@ export default function useContent() {
     return getNested([section, subsection, key], fallback);
   };
 
-  return { getTextContent, getImageContent, loading, error };
+  const updateContent = async (section, subsection, key, value) => {
+    try {
+      const res = await fetch('/api/content', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ section, subsection, key, value }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setContent(data);
+      } else {
+        console.warn('Failed to update content:', res.status);
+      }
+    } catch (err) {
+      console.error('Failed to update content', err);
+    }
+  };
+
+  return { getTextContent, getImageContent, loading, error, updateContent };
 }

--- a/pages/api/content.js
+++ b/pages/api/content.js
@@ -1,0 +1,56 @@
+import { MongoClient } from 'mongodb';
+
+let cachedClient = null;
+
+export default async function handler(req, res) {
+  try {
+    const uri = process.env.MONGODB_URI;
+    if (!uri) {
+      return res.status(500).json({ error: 'MONGODB_URI not configured' });
+    }
+
+    if (!cachedClient) {
+      const client = new MongoClient(uri);
+      cachedClient = await client.connect();
+    }
+
+    const db = cachedClient.db();
+    const collection = db.collection('content');
+
+    if (req.method === 'GET') {
+      const doc = await collection.findOne({ _id: 'content' }) || {};
+      const { _id, ...data } = doc;
+      return res.status(200).json(data);
+    }
+
+    if (req.method === 'PUT') {
+      const { section, subsection, key, value } = req.body || {};
+      if (!section || !subsection || !key) {
+        return res.status(400).json({ error: 'section, subsection and key are required' });
+      }
+      const path = `${section}.${subsection}.${key}`;
+      await collection.updateOne(
+        { _id: 'content' },
+        { $set: { [path]: value } },
+        { upsert: true }
+      );
+      const doc = await collection.findOne({ _id: 'content' }) || {};
+      const { _id, ...data } = doc;
+      return res.status(200).json(data);
+    }
+
+    res.setHeader('Allow', ['GET', 'PUT']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error('Failed to handle content request', err);
+    return res.status(500).json({ error: 'Failed to handle content request' });
+  }
+}
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '8mb',
+    },
+  },
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,10 +9,11 @@ import Head from 'next/head';
 import React, { useEffect, useState } from "react";
 import { useArticles } from '../context/ArticlesContext';
 import useContent from '../hooks/useContent';
+import HeroBannerEditor from '../components/HeroBannerEditor';
 
 export default function Home() {
     const { articles, loading: articlesLoading } = useArticles();
-    const { getTextContent, getImageContent, loading: contentLoading, error: contentError } = useContent();
+    const { getTextContent, getImageContent, loading: contentLoading, error: contentError, updateContent } = useContent();
     const [isAdmin, setIsAdmin] = useState(false);
     
     // Get dynamic content with fallbacks
@@ -66,6 +67,11 @@ export default function Home() {
                         <h2 className="text-4xl text-center text-white mt-4">{heroSubtitle}</h2>
                     </div>
                 </div>
+                {isAdmin && (
+                    <div className="max-w-6xl mx-auto px-4">
+                        <HeroBannerEditor currentImage={heroBanner} updateContent={updateContent} />
+                    </div>
+                )}
                 <section className="recent-articles">
                     <h2 className="text-2xl text-center mt-8 mb-4">{recentArticlesTitle}</h2>
                     <div className="article-cards-container">


### PR DESCRIPTION
## Summary
- add content API to store and update hero banner image
- create editor component so admins can upload a new front-page banner
- extend content hook to support updating values
- expose banner editor on home page for admins

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2dd721818832db152773be49cf58a