### PR TITLE
Clear preview after banner update

### DIFF
--- a/components/HeroBannerEditor.js
+++ b/components/HeroBannerEditor.js
@@ -20,6 +20,7 @@ export default function HeroBannerEditor({ currentImage, updateContent }) {
     if (!image) return;
     await updateContent('home', 'hero', 'hero_banner', image);
     setImage('');
+    setPreview('');
   };
 
   return (


### PR DESCRIPTION
## Summary
- Clear preview image after saving hero banner so only the live banner remains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e0a7d850832db574007fdc591ab2