### PR TITLE
Refresh comité list after updates and shrink member images

### DIFF
--- a/hooks/useUsers.js
+++ b/hooks/useUsers.js
@@ -32,8 +32,8 @@ export default function useUsers() {
         body: JSON.stringify(user),
       });
       if (res.ok) {
-        const { id } = await res.json();
-        setUsers((prev) => [...prev, { ...user, id }]);
+        setLoading(true);
+        await fetchUsers();
       } else {
         console.warn('Failed to add user:', res.status);
       }
@@ -46,7 +46,8 @@ export default function useUsers() {
     try {
       const res = await fetch(`/api/users?id=${id}`, { method: 'DELETE' });
       if (res.ok) {
-        setUsers((prev) => prev.filter((user) => user.id !== id));
+        setLoading(true);
+        await fetchUsers();
       } else {
         console.warn('Failed to delete user:', res.status);
       }

--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -56,10 +56,10 @@ export default function NotreComite() {
                 {loading ? (
                     <p>Loading...</p>
                 ) : (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 justify-items-center">
                         {users.map((member) => (
                             <div key={member.id} className="flex flex-col items-center text-center">
-                                <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
+                                <img src={member.profilePicture} alt={member.name} className="rounded-full w-24 h-24 sm:w-32 sm:h-32 lg:w-40 lg:h-40 mb-4 object-cover border-image" />
                                 <h2 className="text-xl font-semibold">{member.name}</h2>
                                 <p className="text-gray-600">{member.title}</p>
                                 {isAdmin && (


### PR DESCRIPTION
## Summary
- Reload committee members after adding or removing to support multiple entries
- Reduce member image sizes and adjust grid to display three per row

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e4d6a49c832d853f6d91fc5a0cef