### PR TITLE
Replace footer login form with sign out button when admin

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,11 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 export default function Footer() {
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
+    const [isAdmin, setIsAdmin] = useState(false);
     const router = useRouter();
+
+    useEffect(() => {
+        setIsAdmin(document.cookie.includes('admin-auth=true'));
+    }, []);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -22,31 +27,45 @@ export default function Footer() {
         }
     };
 
+    const handleSignOut = () => {
+        document.cookie = 'admin-auth=; Path=/; Max-Age=0';
+        router.reload();
+    };
+
     return (
         <footer className="footer">
             <div className="footer-content flex flex-col sm:flex-row sm:items-center sm:justify-between">
                 <span>©2024 Comité Femmes et Droit UdeM</span>
-                <form onSubmit={handleSubmit} className="mt-2 sm:mt-0 flex space-x-2">
-                    <input
-                        className="border p-1"
-                        type="text"
-                        placeholder="Username"
-                        value={username}
-                        onChange={(e) => setUsername(e.target.value)}
-                    />
-                    <input
-                        className="border p-1"
-                        type="password"
-                        placeholder="Password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                    />
-                    <button className="bg-blue-500 text-white px-3 py-1" type="submit">
-                        Login
+                {isAdmin ? (
+                    <button
+                        className="bg-blue-500 text-white px-3 py-1 mt-2 sm:mt-0"
+                        onClick={handleSignOut}
+                    >
+                        Sign Out
                     </button>
-                </form>
+                ) : (
+                    <form onSubmit={handleSubmit} className="mt-2 sm:mt-0 flex space-x-2">
+                        <input
+                            className="border p-1"
+                            type="text"
+                            placeholder="Username"
+                            value={username}
+                            onChange={(e) => setUsername(e.target.value)}
+                        />
+                        <input
+                            className="border p-1"
+                            type="password"
+                            placeholder="Password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                        />
+                        <button className="bg-blue-500 text-white px-3 py-1" type="submit">
+                            Login
+                        </button>
+                    </form>
+                )}
             </div>
-            {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+            {error && !isAdmin && <p className="text-red-500 text-sm mt-1">{error}</p>}
         </footer>
     );
 }


### PR DESCRIPTION
## Summary
- Show a sign-out button in the footer when the admin cookie is present.
- Allow admins to sign out by clearing the cookie and reloading the page.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e6522148832d8b0b70ef997c77af