### PR TITLE
Allow adding committee members without pictures

### DIFF
--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -25,10 +25,14 @@ export default async function handler(req, res) {
 
     if (req.method === 'POST') {
       const { title, name, profilePicture } = req.body;
-      if (!title || !name || !profilePicture) {
-        return res.status(400).json({ error: 'title, name and profilePicture are required' });
+      if (!title || !name) {
+        return res.status(400).json({ error: 'title and name are required' });
       }
-      const result = await collection.insertOne({ title, name, profilePicture });
+      const result = await collection.insertOne({
+        title,
+        name,
+        profilePicture: profilePicture || '',
+      });
       return res.status(201).json({ id: result.insertedId.toString() });
     }
 
@@ -59,7 +63,7 @@ export default async function handler(req, res) {
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '4mb',
+      sizeLimit: '8mb',
     },
   },
 };


### PR DESCRIPTION
## Summary
- permit adding committee members without requiring a profile photo
- raise committee member upload limit to 8MB

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c2e8f07c60832da6c58046b9c86e8e