### PR TITLE
Normalize committee member avatars

### DIFF
--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -59,7 +59,11 @@ export default function NotreComite() {
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 justify-items-center">
                         {users.map((member) => (
                             <div key={member.id} className="flex flex-col items-center text-center">
-                                <img src={member.profilePicture} alt={member.name} className="rounded-full w-24 h-24 sm:w-32 sm:h-32 lg:w-40 lg:h-40 mb-4 object-cover border-image" />
+                                <img
+                                    src={member.profilePicture}
+                                    alt={member.name}
+                                    className="committee-avatar mb-4 border-image"
+                                />
                                 <h2 className="text-xl font-semibold">{member.name}</h2>
                                 <p className="text-gray-600">{member.title}</p>
                                 {isAdmin && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -702,6 +702,13 @@ button[type="submit"]:hover {
     border-radius: 50%; /* Ensure the border is circular */
 }
 
+.committee-avatar {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
 /* Scroller container */
 .scroller {
     overflow: hidden;


### PR DESCRIPTION
## Summary
- Ensure committee member images render at a consistent size by introducing a dedicated avatar class
- Apply the new avatar class on the Notre Comité page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eacfc318832db7c833442063f7a3