### PR TITLE
Ensure three committee members per row and enlarge avatars

### DIFF
--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -56,7 +56,7 @@ export default function NotreComite() {
                 {loading ? (
                     <p>Loading...</p>
                 ) : (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 justify-items-center">
+                    <div className="grid grid-cols-3 gap-8 justify-items-center">
                         {users.map((member) => (
                             <div key={member.id} className="flex flex-col items-center text-center">
                                 <img

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -703,8 +703,8 @@ button[type="submit"]:hover {
 }
 
 .committee-avatar {
-    width: 120px;
-    height: 120px;
+    width: 360px;
+    height: 360px;
     object-fit: cover;
     border-radius: 50%;
 }


### PR DESCRIPTION
## Summary
- Force committee listing to always show three members per row
- Enlarge committee member avatars for greater prominence

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68c2edd23b8c832dacb47d831c90c810