### PR TITLE
Display committee members in columns of three

### DIFF
--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -56,7 +56,7 @@ export default function NotreComite() {
                 {loading ? (
                     <p>Loading...</p>
                 ) : (
-                    <div className="grid grid-cols-3 gap-8 justify-items-center">
+                    <div className="grid grid-rows-3 grid-flow-col gap-8 justify-items-center">
                         {users.map((member) => (
                             <div key={member.id} className="flex flex-col items-center text-center">
                                 <img


### PR DESCRIPTION
## Summary
- Arrange committee member grid to fill by columns with three users per column

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; attempt to install next returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eeda2724832da4e53f397929897f