### PR TITLE
Display committee members in three-column grid

### DIFF
--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -56,7 +56,7 @@ export default function NotreComite() {
                 {loading ? (
                     <p>Loading...</p>
                 ) : (
-                    <div className="grid grid-rows-3 grid-flow-col gap-8 justify-items-center">
+                    <div className="grid grid-cols-3 gap-8 justify-items-center">
                         {users.map((member) => (
                             <div key={member.id} className="flex flex-col items-center text-center">
                                 <img


### PR DESCRIPTION
## Summary
- Ensure committee members render in a three-column layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f023d58c832da90986afd50b3ed2