### PR TITLE
Ensure committee members display three per row

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -138,6 +138,18 @@ nav a {
     gap: 2rem;
 }
 
+.grid-cols-3 {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.gap-8 {
+    gap: 2rem;
+}
+
+.justify-items-center {
+    justify-items: center;
+}
+
 .rounded-full {
     border-radius: 50%;
 }
@@ -851,8 +863,7 @@ button[type="submit"]:hover {
     }
 
     .grid {
-        display: flex;
-        flex-direction: column;
+        display: grid;
         gap: 1rem;
     }
 


### PR DESCRIPTION
## Summary
- Add utility classes to support three-column grid layout for committee members
- Keep grid layout on small screens so profiles no longer stack vertically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f1bd8344832dbb9bc045c51a9506