### PR TITLE
feat: improve blog article cards

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-// Format raw article data into a unified shape
+// Normalize raw article data
 function formatArticle(raw = {}) {
   const {
     _id,
@@ -11,12 +11,7 @@ function formatArticle(raw = {}) {
     image,
     imageUrl,
     coverImage,
-    author = {},
-    authorName,
-    authorImage,
     date = '',
-    category,
-    tag,
   } = raw;
 
   return {
@@ -24,43 +19,23 @@ function formatArticle(raw = {}) {
     title,
     body: body || content || '',
     image: image || imageUrl || coverImage || 'https://placehold.co/600x400',
-    author: {
-      name: author.name || authorName || 'Unknown',
-      image: author.profilePic || authorImage || 'https://placehold.co/48',
-    },
     date,
-    category: category || tag || '',
   };
 }
 
-// Compact article preview card
+// Article preview card
 export default function ArticleCard({ article = {} }) {
   const a = formatArticle(article);
-  const excerpt = a.body.length > 80 ? `${a.body.slice(0, 80)}...` : a.body;
+  const excerpt = a.body.length > 200 ? `${a.body.slice(0, 200)}...` : a.body;
 
   return (
     <Link href={`/articles/${a.id}`}>
-      <article className="max-w-xs overflow-hidden rounded-lg bg-white shadow transition-shadow duration-200 hover:shadow-lg">
-        <div className="relative h-36 w-full">
-          <img src={a.image} alt={a.title} className="h-full w-full object-cover" />
-          {a.category && (
-            <span className="absolute left-2 top-2 rounded-full bg-blue-600 px-2 py-0.5 text-[10px] font-medium text-white">
-              {a.category}
-            </span>
-          )}
-        </div>
-        <div className="space-y-2 p-4">
-          <h3 className="text-sm font-semibold leading-snug">{a.title}</h3>
-          <p className="text-xs text-gray-600">{excerpt}</p>
-          <div className="flex items-center border-t pt-2 text-xs text-gray-500">
-            <img
-              src={a.author.image}
-              alt={a.author.name}
-              className="mr-2 h-6 w-6 rounded-full object-cover"
-            />
-            <span className="mr-auto">{a.author.name}</span>
-            {a.date && <span>{a.date}</span>}
-          </div>
+      <article className="overflow-hidden rounded-lg bg-white shadow transition-shadow duration-200 hover:shadow-lg">
+        <img src={a.image} alt={a.title} className="h-48 w-full object-cover" />
+        <div className="p-4">
+          <h3 className="mb-2 text-lg font-semibold">{a.title}</h3>
+          {a.date && <p className="mb-2 text-sm text-gray-500">{a.date}</p>}
+          <p className="text-sm text-gray-700">{excerpt}</p>
         </div>
       </article>
     </Link>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -38,7 +38,7 @@ export default function Blog() {
                 <meta name="keywords" content="féminisme, blog, articles, Université de Montréal, communauté"/>
             </Head>
             <Navbar/>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div className="grid grid-cols-3 gap-8">
                 {posts.map((article) => (
                     <ArticleCard key={article.id || article._id} article={article} />
                 ))}


### PR DESCRIPTION
## Summary
- show cover image, title, date and excerpt in article cards
- layout blog page with a three-column grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f66db93c832da93a445b9aa42aa6