### PR TITLE
Normalize article card image size

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -31,7 +31,9 @@ export default function ArticleCard({ article = {} }) {
   return (
     <Link href={`/articles/${a.id}`}>
       <article className="overflow-hidden rounded-lg bg-white shadow transition-shadow duration-200 hover:shadow-lg">
-        <img src={a.image} alt={a.title} className="h-48 w-full object-cover" />
+        <div className="h-48 w-full overflow-hidden">
+          <img src={a.image} alt={a.title} className="h-full w-full object-cover" />
+        </div>
         <div className="p-4">
           <h3 className="mb-2 text-lg font-semibold">{a.title}</h3>
           {a.date && <p className="mb-2 text-sm text-gray-500">{a.date}</p>}


### PR DESCRIPTION
## Summary
- ensure article card images render within a fixed-height container for consistent sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2f7713e48832dad7ec7d4dd316ff7