### PR TITLE
Fix blog article image aspect ratio

### DIFF
--- a/pages/blog.js
+++ b/pages/blog.js
@@ -38,11 +38,13 @@ export default function Blog() {
                 <meta name="keywords" content="féminisme, blog, articles, Université de Montréal, communauté"/>
             </Head>
             <Navbar/>
-            <div className="grid grid-cols-3 gap-8">
-                {posts.map((article) => (
-                    <ArticleCard key={article.id || article._id} article={article} />
-                ))}
-            </div>
+            <section className="recent-articles">
+                <div className="article-cards-container">
+                    {posts.map((article) => (
+                        <ArticleCard key={article.id || article._id} article={article} />
+                    ))}
+                </div>
+            </section>
             {!isAdmin && (
                 <div className="my-8">
                     <h2 className="text-xl font-bold mb-2">Admin Login</h2>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -285,8 +285,7 @@ nav a {
 
 .article-card-image {
     width: 100%;
-    height: 150px;
-    object-fit: cover;
+    height: auto;
 }
 
 .heart-button {


### PR DESCRIPTION
## Summary
- ensure blog article list uses home page card layout for consistent image scaling
- remove fixed height from article card images to preserve aspect ratio

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fbc93214832da176eafbba899d2d