### PR TITLE
Add missing Next.js and React dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "mongodb": "^5.8.0",
     "nodemailer": "^6.9.11",
     "@tiptap/react": "latest",
-    "@tiptap/starter-kit": "latest"
+    "@tiptap/starter-kit": "latest",
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- fix `package.json` syntax and add Next.js and React related dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tiptap%2freact)*
- `npm test` *(fails: Missing script: "test")*
- `npm run dev` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c303939c80832d8b68593fe309a690