### PR TITLE
Add Tiptap SimpleEditor for blog content

### DIFF
--- a/components/ArticleForm.js
+++ b/components/ArticleForm.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import Tiptap from './Tiptap';
+import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor';
 
 export default function ArticleForm({ article, onSubmit, onCancel }) {
   const [formData, setFormData] = useState({
@@ -138,7 +138,7 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Article Content *
           </label>
-          <Tiptap
+          <SimpleEditor
             value={formData.content}
             onChange={(val) =>
               setFormData((prev) => ({

--- a/components/tiptap-templates/simple/simple-editor.js
+++ b/components/tiptap-templates/simple/simple-editor.js
@@ -1,15 +1,13 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useEffect } from 'react'
 
-export default function Tiptap({ value = '', onChange = () => {} }) {
+export function SimpleEditor({ value = '', onChange = () => {} }) {
   const editor = useEditor({
     extensions: [StarterKit],
     content: value,
-    // Don't render immediately on the server to avoid SSR issues
-    immediatelyRender: false,
     onUpdate({ editor }) {
       onChange(editor.getHTML())
     }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace Tiptap component with SimpleEditor for article content field
- Add SimpleEditor implementation under `tiptap-templates`
- Configure path alias with jsconfig

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3064e1fc0832da75dc498dbdd7793