### PR TITLE
fix tiptap ssr render issue

### DIFF
--- a/components/tiptap-templates/simple/simple-editor.js
+++ b/components/tiptap-templates/simple/simple-editor.js
@@ -8,6 +8,7 @@ export function SimpleEditor({ value = '', onChange = () => {} }) {
   const editor = useEditor({
     extensions: [StarterKit],
     content: value,
+    immediatelyRender: false,
     onUpdate({ editor }) {
       onChange(editor.getHTML())
     }


### PR DESCRIPTION
## Summary
- avoid hydration mismatch by disabling immediate rendering when initializing Tiptap editor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30875bc68832d93a262725732546c