### PR TITLE
feat: enhance article creation

### DIFF
--- a/components/ArticleForm.js
+++ b/components/ArticleForm.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { SimpleEditor } from '@/components/tiptap-templates/simple/simple-editor';
+import useUsers from '@/hooks/useUsers';
+import RichTextEditor from '@/components/RichTextEditor';
 
 export default function ArticleForm({ article, onSubmit, onCancel }) {
   const [formData, setFormData] = useState({
@@ -10,6 +11,7 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
     image: '',
     date: new Date().toISOString().split('T')[0]
   });
+  const { users } = useUsers();
 
   useEffect(() => {
     if (article) {
@@ -37,8 +39,28 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
     }));
   };
 
+  const handleAuthorChange = (e) => {
+    const selectedName = e.target.value;
+    const selectedUser = users.find(u => u.name === selectedName);
+    setFormData(prev => ({
+      ...prev,
+      author: selectedName,
+      authorImage: selectedUser ? selectedUser.profilePicture : ''
+    }));
+  };
+
+  const handleImageUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setFormData(prev => ({ ...prev, image: reader.result }));
+    };
+    reader.readAsDataURL(file);
+  };
+
   return (
-    <div className="bg-white rounded-lg shadow-lg p-6">
+    <div className="bg-gradient-to-r from-purple-50 to-blue-50 rounded-xl shadow-lg p-6 max-w-3xl mx-auto">
       <h3 className="text-xl font-semibold mb-4">
         {article ? 'Edit Article' : 'Create New Article'}
       </h3>
@@ -62,62 +84,47 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
           
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              Author Name *
+              Author *
             </label>
-            <input
-              type="text"
+            <select
               name="author"
               value={formData.author}
-              onChange={handleChange}
+              onChange={handleAuthorChange}
               className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Enter author name"
               required
-            />
-          </div>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Author Image URL
-            </label>
-            <input
-              type="text"
-              name="authorImage"
-              value={formData.authorImage}
-              onChange={handleChange}
-              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="e.g., /images/author.jpg"
-            />
+            >
+              <option value="">Select author</option>
+              {users.map(user => (
+                <option key={user.id} value={user.name}>{user.name}</option>
+              ))}
+            </select>
             {formData.authorImage && (
-              <img 
-                src={formData.authorImage} 
-                alt="Author preview" 
+              <img
+                src={formData.authorImage}
+                alt="Author preview"
                 className="w-12 h-12 rounded-full object-cover mt-2"
               />
             )}
           </div>
-          
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Article Image URL
-            </label>
-            <input
-              type="text"
-              name="image"
-              value={formData.image}
-              onChange={handleChange}
-              className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="e.g., /images/article.jpg"
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Cover Image
+          </label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImageUpload}
+            className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          {formData.image && (
+            <img
+              src={formData.image}
+              alt="Article preview"
+              className="w-20 h-20 object-cover rounded mt-2"
             />
-            {formData.image && (
-              <img 
-                src={formData.image} 
-                alt="Article preview" 
-                className="w-20 h-20 object-cover rounded mt-2"
-              />
-            )}
-          </div>
+          )}
         </div>
         
         <div>
@@ -138,7 +145,7 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Article Content *
           </label>
-          <SimpleEditor
+          <RichTextEditor
             value={formData.content}
             onChange={(val) =>
               setFormData((prev) => ({

--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -1,0 +1,78 @@
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Image from '@tiptap/extension-image';
+import { useEffect, useRef } from 'react';
+
+export default function RichTextEditor({ value = '', onChange = () => {} }) {
+  const fileInput = useRef(null);
+  const editor = useEditor({
+    extensions: [StarterKit, Image],
+    content: value,
+    immediatelyRender: false,
+    onUpdate({ editor }) {
+      onChange(editor.getHTML());
+    },
+  });
+
+  useEffect(() => {
+    if (editor && value !== editor.getHTML()) {
+      editor.commands.setContent(value);
+    }
+  }, [editor, value]);
+
+  const addImage = (file) => {
+    if (!editor) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      editor.chain().focus().setImage({ src: reader.result }).run();
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex flex-wrap items-center gap-2 bg-gray-50 p-2 border-b">
+        <button
+          type="button"
+          onClick={() => editor && editor.chain().focus().toggleBold().run()}
+          className={`p-1 rounded ${editor?.isActive('bold') ? 'bg-gray-200' : ''}`}
+        >
+          <b>B</b>
+        </button>
+        <button
+          type="button"
+          onClick={() => editor && editor.chain().focus().toggleItalic().run()}
+          className={`p-1 rounded ${editor?.isActive('italic') ? 'bg-gray-200' : ''}`}
+        >
+          <i>I</i>
+        </button>
+        <button
+          type="button"
+          onClick={() => editor && editor.chain().focus().toggleBulletList().run()}
+          className={`p-1 rounded ${editor?.isActive('bulletList') ? 'bg-gray-200' : ''}`}
+        >
+          •
+        </button>
+        <button
+          type="button"
+          onClick={() => fileInput.current?.click()}
+          className="p-1 rounded"
+        >
+          📷
+        </button>
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInput}
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) addImage(file);
+            e.target.value = '';
+          }}
+        />
+      </div>
+      <EditorContent editor={editor} className="p-2 min-h-[200px] bg-white" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add author dropdown that pulls names and profile pictures from stored users
- allow cover image uploads and swap editor for richer formatting with inline images
- style article creation form with gradient background and modern toolbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install next` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tiptap%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68c30d621e54832daa9ca0770644cbd9