### PR TITLE
Add Tiptap image extension dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mongodb": "^5.8.0",
     "nodemailer": "^6.9.11",
     "@tiptap/react": "latest",
-    "@tiptap/starter-kit": "latest"
+    "@tiptap/starter-kit": "latest",
+    "@tiptap/extension-image": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- fix missing module error by adding `@tiptap/extension-image`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ffc74e8832d8acba2dfb80972d8