### PR TITLE
Normalize article editor images

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -24,7 +24,15 @@ export default function RichTextEditor({ value = '', onChange = () => {} }) {
     if (!editor) return;
     const reader = new FileReader();
     reader.onload = () => {
-      editor.chain().focus().setImage({ src: reader.result }).run();
+      // Limit image size to prevent oversized images in the editor and saved content
+      editor
+        .chain()
+        .focus()
+        .setImage({
+          src: reader.result,
+          style: 'max-width: 300px; height: auto;'
+        })
+        .run();
     };
     reader.readAsDataURL(file);
   };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -291,6 +291,15 @@ nav a {
     display: block;
 }
 
+/* Ensure images embedded in articles and the editor aren't oversized */
+.ProseMirror img,
+.prose img {
+    max-width: 300px;
+    height: auto;
+    display: block;
+    margin: 0.5rem auto;
+}
+
 .heart-button {
     background: none;
     border: none;


### PR DESCRIPTION
## Summary
- limit images inserted in the rich text editor to 300px width
- add global styles so article content images render at a reasonable size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3128f0168832d93ffe63645fa7a5c