### PR TITLE
Remove author and article previews from article form

### DIFF
--- a/components/ArticleForm.js
+++ b/components/ArticleForm.js
@@ -98,13 +98,7 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
                 <option key={user.id} value={user.name}>{user.name}</option>
               ))}
             </select>
-            {formData.authorImage && (
-              <img
-                src={formData.authorImage}
-                alt="Author preview"
-                className="w-12 h-12 rounded-full object-cover mt-2"
-              />
-            )}
+            {/* Author preview removed as per new requirements */}
           </div>
         </div>
 
@@ -118,13 +112,7 @@ export default function ArticleForm({ article, onSubmit, onCancel }) {
             onChange={handleImageUpload}
             className="border border-gray-300 p-2 rounded w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           />
-          {formData.image && (
-            <img
-              src={formData.image}
-              alt="Article preview"
-              className="w-20 h-20 object-cover rounded mt-2"
-            />
-          )}
+          {/* Article preview removed as per new requirements */}
         </div>
         
         <div>


### PR DESCRIPTION
## Summary
- Remove author image preview after an author is selected when creating or editing an article
- Remove cover image preview when uploading an article's cover image

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install next --no-save` *(fails: 403 Forbidden for @tiptap/extension-image)*

------
https://chatgpt.com/codex/tasks/task_e_68c3154e5510832db52cfe6514a27bfe