### PR TITLE
Center and enlarge calendar

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -73,7 +73,7 @@ export default function Evenements() {
           <div>Loading...</div>
         ) : (
           <div>
-            <div className="my-4">
+          <div className="my-4 flex justify-center">
               <Calendar
                 aria-label="Calendrier des événements"
                 className="calendar"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -786,7 +786,9 @@ button[type="submit"]:hover {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: 80%;
+    width: fit-content;
+    transform: scale(3);
+    transform-origin: center;
 }
 
 
@@ -818,7 +820,7 @@ button[type="submit"]:hover {
     }
 
     .calendar {
-        width: 100%;
+        width: fit-content;
         max-width: none;
     }
 


### PR DESCRIPTION
## Summary
- Center calendar layout on events page
- Enlarge calendar by scaling CSS and removing width constraints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c358154188832dbacd6d2aac66b63a