### PR TITLE
Keep calendar from overlapping footer

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -33,12 +33,12 @@ export default function Evenements() {
   };
 
   return (
-    <div>
+    <div className="flex flex-col min-h-screen">
       <Head>
         <title>Événements</title>
       </Head>
       <Navbar />
-      <main className="max-w-4xl mx-auto p-4">
+      <main className="flex-grow max-w-4xl mx-auto p-4">
         <h1 className="text-3xl text-center mb-4">Événements</h1>
         {isAdmin && (
           <form onSubmit={handleSubmit} className="mb-8 space-y-2">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -787,8 +787,6 @@ button[type="submit"]:hover {
     margin-left: auto;
     margin-right: auto;
     width: fit-content;
-    transform: scale(3);
-    transform-origin: center;
 }
 
 


### PR DESCRIPTION
## Summary
- make events page layout fill the viewport so the footer stays at the bottom
- remove calendar scaling that caused it to overlap other content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c35b255b08832d9553b4436bd70db4