### PR TITLE
Normalize blog image sizes

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -284,8 +284,8 @@ nav a {
 }
 
 .article-card-image {
-    width: 150px;
-    height: 150px;
+    width: 120px;
+    height: 120px;
     object-fit: cover;
     margin: 0.5rem auto;
     display: block;
@@ -293,8 +293,9 @@ nav a {
 
 /* Ensure images embedded in articles and the editor aren't oversized */
 .ProseMirror img,
-.prose img {
-    max-width: 300px;
+.prose img,
+.article-box img {
+    max-width: 200px;
     height: auto;
     display: block;
     margin: 0.5rem auto;


### PR DESCRIPTION
## Summary
- Shrink article preview thumbnails and cap embedded article images at 200px
- Ensure images within article content are centered and fit inside the article box

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4639a1dbc832d944e2f69132d3872