### PR TITLE
Center contact form labels and set email recipient

### DIFF
--- a/components/ContactCard.js
+++ b/components/ContactCard.js
@@ -47,8 +47,8 @@ export default function ContactCard({ leftContent, rightContent }) {
                 </div>
                 <div className="right-side">
                     <form onSubmit={handleSubmit} className="contact-form">
-                        <div className="mb-4">
-                            <label htmlFor="nom" className="block text-sm font-semibold mb-2">Nom</label>
+                        <div className="mb-4 flex flex-col items-center">
+                            <label htmlFor="nom" className="block text-sm font-semibold mb-2 text-center">Nom</label>
                             <input
                                 type="text"
                                 id="nom"
@@ -59,8 +59,8 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 placeholder="Votre nom"
                             />
                         </div>
-                        <div className="mb-4">
-                            <label htmlFor="email" className="block text-sm font-semibold mb-2">Courriel</label>
+                        <div className="mb-4 flex flex-col items-center">
+                            <label htmlFor="email" className="block text-sm font-semibold mb-2 text-center">Courriel</label>
                             <input
                                 type="email"
                                 id="email"
@@ -71,8 +71,8 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 placeholder="Votre Courriel"
                             />
                         </div>
-                        <div className="mb-4">
-                            <label htmlFor="objet" className="block text-sm font-semibold mb-2">Objet</label>
+                        <div className="mb-4 flex flex-col items-center">
+                            <label htmlFor="objet" className="block text-sm font-semibold mb-2 text-center">Objet</label>
                             <input
                                 type="text"
                                 id="objet"
@@ -83,8 +83,8 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 placeholder="Objet de votre message"
                             />
                         </div>
-                        <div className="mb-4">
-                            <label htmlFor="message" className="block text-sm font-semibold mb-2">Message</label>
+                        <div className="mb-4 flex flex-col items-center">
+                            <label htmlFor="message" className="block text-sm font-semibold mb-2 text-center">Message</label>
                             <textarea
                                 id="message"
                                 name="message"

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
     try {
         await transporter.sendMail({
             from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
-            to: process.env.EMAIL_TO || process.env.EMAIL_USER,
+            to: 'femmesetdroit.udem@gmail.com',
             subject: `Contact Form: ${objet}`,
             text: `Nom: ${nom}\nEmail: ${email}\n\n${message}`,
             replyTo: email


### PR DESCRIPTION
## Summary
- Send contact form submissions to femmesetdroit.udem@gmail.com
- Center and stack labels above inputs on the contact page

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c469977fe8832d8a387579a467b946