### PR TITLE
style: enhance article card visuals

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -31,12 +31,12 @@ export default function ArticleCard({ article = {} }) {
 
   return (
     <Link href={`/articles/${a.id}`}>
-      <article className="overflow-hidden rounded-lg bg-white shadow transition-shadow duration-200 hover:shadow-lg">
+      <article className="max-w-md overflow-hidden rounded-xl bg-white shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl">
         <img src={a.image} alt={a.title} className="article-card-image" />
-        <div className="p-4">
-          <h3 className="mb-2 text-lg font-semibold">{a.title}</h3>
-          {a.date && <p className="mb-2 text-sm text-gray-500">{a.date}</p>}
-          <p className="text-sm text-gray-700">{excerpt}</p>
+        <div className="p-6">
+          <h3 className="mb-3 text-2xl font-bold text-gray-800">{a.title}</h3>
+          {a.date && <p className="mb-3 text-sm text-gray-500">{a.date}</p>}
+          <p className="text-base text-gray-600">{excerpt}</p>
         </div>
       </article>
     </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -280,16 +280,16 @@ nav a {
 
 .article-cards-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
     justify-items: center;
 }
 
 .article-card-image {
-    width: 120px;
-    height: 120px;
+    width: 100%;
+    height: 200px;
     object-fit: cover;
-    margin: 0.5rem auto;
+    margin: 0;
     display: block;
 }
 


### PR DESCRIPTION
## Summary
- enlarge article cards with full-width images and animated hover effect
- increase article title size and spacing for professional look
- widen article card grid for roomier layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npx next lint` *(fails: 403 Forbidden installing next)*

------
https://chatgpt.com/codex/tasks/task_e_68c46e915124832d9c40aa86df39f71d