### PR TITLE
feat: unify background and article card styling

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -31,9 +31,9 @@ export default function ArticleCard({ article = {} }) {
 
   return (
     <Link href={`/articles/${a.id}`}>
-      <article className="max-w-md overflow-hidden rounded-xl bg-white shadow-md transition duration-300 hover:-translate-y-1 hover:shadow-xl">
+      <article className="article-card max-w-md h-full flex flex-col overflow-hidden rounded-xl shadow-md">
         <img src={a.image} alt={a.title} className="article-card-image" />
-        <div className="p-6">
+        <div className="p-6 flex flex-col flex-grow">
           <h3 className="mb-3 text-2xl font-bold text-gray-800">{a.title}</h3>
           {a.date && <p className="mb-3 text-sm text-gray-500">{a.date}</p>}
           <p className="text-base text-gray-600">{excerpt}</p>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -14,7 +14,7 @@ export default function Navbar() {
     const isActive = (path) => router.pathname === path;
 
     return (
-        <nav className="bg-white p-4 flex items-center justify-center">
+        <nav className="bg-[#e8e0e0] p-4 flex items-center justify-center">
             <div className={`logo-container ${isOpen ? 'hidden' : ''}`}>
                 <a href="/">
                     <img src="/images/logo femme et droit-Photoroom.png" alt="Logo" className="logo w-10 h-10" />

--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -80,7 +80,7 @@ export default function RichTextEditor({ value = '', onChange = () => {} }) {
           }}
         />
       </div>
-      <EditorContent editor={editor} className="p-2 min-h-[200px] bg-white" />
+      <EditorContent editor={editor} className="p-2 min-h-[200px] bg-[#e8e0e0]" />
     </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -116,7 +116,7 @@ a {
 }
 
 nav {
-    background-color: #ffffff;
+    background-color: #e8e0e0;
 }
 
 nav ul {
@@ -224,7 +224,7 @@ nav a {
 
 /* navbar backround colour */
 .bg-white {
-    background-color: #f0efe9;
+    background-color: #e8e0e0;
 }
 
 .text-black {
@@ -275,7 +275,7 @@ nav a {
 
 .recent-articles {
     padding: 2rem;
-    background-color: #f9f9f9;
+    background-color: #e8e0e0;
 }
 
 .article-cards-container {
@@ -283,6 +283,21 @@ nav a {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 1.5rem;
     justify-items: center;
+    align-items: stretch;
+    grid-auto-rows: 1fr;
+}
+
+.article-card {
+    background-color: #e8e0e0;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.article-card:hover {
+    transform: scale(1.1);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
 }
 
 .article-card-image {
@@ -491,7 +506,7 @@ button[type="submit"]:hover {
 }
 
 .modal-content {
-    background-color: white;
+    background-color: #e8e0e0;
     padding: 1rem;
     border-radius: 0.5rem;
     position: relative;
@@ -535,7 +550,7 @@ button[type="submit"]:hover {
 }
 .footer {
     margin-top: auto;
-    background-color: #eeede8;
+    background-color: #e8e0e0;
     color: #000000;
     padding: 1rem;
     text-align: center;
@@ -634,7 +649,7 @@ button[type="submit"]:hover {
     padding: 3rem;
     border-radius: 0.25rem;
     margin: 2rem auto;
-    background-color: #eeede8;
+    background-color: #e8e0e0;
     max-width: 800px;
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- set global background color to #e8e0e0 across navigation, footers, and content containers
- enforce uniform article card sizes with consistent hover scale animation
- align editor background with overall theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c473df1c50832db93699ce067bae2b