### PR TITLE
Ensure footer sticks to bottom

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,6 +11,7 @@ html, body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    flex: 1;
 }
 
 main {


### PR DESCRIPTION
## Summary
- Make Next.js root element flex:1 so pages fill viewport and footer stays at bottom

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c4757008a8832da440c4e14b328322