### PR TITLE
Move sponsors bar above footer

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import '../styles/globals.css';
 import { ArticlesProvider } from '../context/ArticlesContext';
 import { MantineProvider } from '@mantine/core';
 import Footer from '../components/Footer';
+import SponsorsBar from '../components/Sponsors';
 
 export default function MyApp({ Component, pageProps }) {
   return (
@@ -11,7 +12,10 @@ export default function MyApp({ Component, pageProps }) {
       <ArticlesProvider>
         <div className="flex-wrapper">
           <Component {...pageProps} />
-          <Footer />
+          <div>
+            <SponsorsBar />
+            <Footer />
+          </div>
         </div>
       </ArticlesProvider>
     </MantineProvider>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 import { useArticles } from '../context/ArticlesContext';
 import ArticleCard from '../components/ArticleCard';
 import Navbar from '../components/Navbar';
-import SponsorsBar from '../components/Sponsors';
 import ArticleForm from '../components/ArticleForm';
 import Head from 'next/head';
 
@@ -71,7 +70,6 @@ export default function Blog() {
                     </div>
                 ) :
                 null}
-                <SponsorsBar />
                 </main>
             </div>
         </>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@
 import Navbar from '../components/Navbar';
 import ContactCard from '../components/ContactCard';
 import ArticleCard from '../components/ArticleCard';
-import SponsorsBar from "../components/Sponsors";
 import Head from 'next/head';
 import React, { useEffect, useState } from "react";
 import { useArticles } from '../context/ArticlesContext';
@@ -78,7 +77,6 @@ export default function Home() {
                         </div>
                     </section>
                     <ContactCard />
-                    <SponsorsBar />
                 </main>
             </div>
         </>

--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -2,7 +2,6 @@
 import Navbar from "../components/Navbar";
 import Head from "next/head";
 import React, { useEffect, useRef, useState } from "react";
-import SponsorsBar from "../components/Sponsors";
 import useUsers from "../hooks/useUsers";
 
 export default function NotreComite() {
@@ -107,7 +106,6 @@ export default function NotreComite() {
                         </form>
                     </div>
                 )}
-                <SponsorsBar />
                 </main>
             </div>
         </>


### PR DESCRIPTION
## Summary
- render moving SponsorsBar above the footer in the app layout
- remove page-level SponsorsBar imports to avoid duplicate display

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: next: not found; dependency installation returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c480de5c74832db191dd6a23306994