### PR TITLE
Style article cards for consistent layout

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -31,12 +31,12 @@ export default function ArticleCard({ article = {} }) {
 
   return (
     <Link href={`/articles/${a.id}`}>
-      <article className="article-card max-w-md h-full flex flex-col overflow-hidden rounded-xl shadow-md">
+      <article className="article-card max-w-md h-full flex flex-col overflow-hidden rounded-2xl shadow-md">
         <img src={a.image} alt={a.title} className="article-card-image" />
         <div className="p-6 flex flex-col flex-grow">
-          <h3 className="mb-3 text-2xl font-bold text-gray-800">{a.title}</h3>
-          {a.date && <p className="mb-3 text-sm text-gray-500">{a.date}</p>}
-          <p className="text-base text-gray-600">{excerpt}</p>
+          <h3 className="mb-1 text-4xl font-bold leading-snug text-gray-800">{a.title}</h3>
+          {a.date && <p className="mb-4 text-sm text-gray-500">{a.date}</p>}
+          <p className="text-base text-gray-600 flex-grow">{excerpt}</p>
         </div>
       </article>
     </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -294,6 +294,9 @@ nav a {
     display: flex;
     flex-direction: column;
     height: 100%;
+    border: 1px solid #e5e7eb;
+    border-radius: 1rem;
+    overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -304,7 +307,8 @@ nav a {
 
 .article-card-image {
     width: 100%;
-    height: 200px;
+    height: auto;
+    aspect-ratio: 16 / 9;
     object-fit: cover;
     margin: 0;
     display: block;


### PR DESCRIPTION
## Summary
- enlarge article card titles and tighten date placement beneath each heading
- ensure card body content stretches evenly within the layout
- add subtle borders, rounded corners, and consistent image sizing for article cards

## Testing
- npm run lint *(fails: next executable not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85c2309bc832d89ec1e7ff8bd1712