### PR TITLE
Adjust events layout to place sidebar beside calendar

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -184,8 +184,8 @@ export default function Evenements() {
           {loading ? (
             <div>Loading...</div>
           ) : (
-            <div className="mt-8 grid gap-8 justify-items-center md:grid-cols-[1fr_auto_auto_1fr] md:items-start">
-              <div className="flex justify-center md:col-start-2 md:col-end-3 md:justify-self-center">
+            <div className="mt-8 grid gap-8 justify-items-center md:grid-cols-[minmax(0,_1fr)_minmax(0,_1fr)] md:items-start md:justify-items-start">
+              <div className="flex justify-center md:justify-start">
                 <div className="w-full max-w-md rounded-2xl bg-white/80 p-4 shadow-md backdrop-blur">
                   <Calendar
                     aria-label="Calendrier des événements"
@@ -211,7 +211,7 @@ export default function Evenements() {
                   />
                 </div>
               </div>
-              <aside className="w-full max-w-md rounded-2xl bg-white/90 p-6 shadow-md backdrop-blur md:col-start-3 md:col-end-4 md:max-w-md md:justify-self-start">
+              <aside className="w-full max-w-md rounded-2xl bg-white/90 p-6 shadow-md backdrop-blur md:max-w-md md:justify-self-start">
                 <h2 className="text-xl font-semibold text-gray-900">
                   Événements de {monthLabel}
                 </h2>


### PR DESCRIPTION
## Summary
- simplify the events page grid to use two responsive columns
- align the calendar and monthly event list side by side on medium screens and above

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bae45b4c832da0c687674d40ff8f