### PR TITLE
Adjust article card spacing

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -32,8 +32,10 @@ export default function ArticleCard({ article = {} }) {
   return (
     <Link href={`/articles/${a.id}`}>
       <article className="article-card max-w-md h-full flex flex-col overflow-hidden rounded-2xl shadow-md">
-        <img src={a.image} alt={a.title} className="article-card-image" />
-        <div className="p-6 flex flex-col flex-grow">
+        <div className="article-card-media">
+          <img src={a.image} alt={a.title} className="article-card-image" />
+        </div>
+        <div className="article-card-content flex flex-col flex-grow">
           <h3 className="mb-1 text-4xl font-bold leading-snug text-gray-800">{a.title}</h3>
           {a.date && <p className="mb-4 text-sm text-gray-500">{a.date}</p>}
           <p className="text-base text-gray-600 flex-grow">{excerpt}</p>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -293,6 +293,9 @@ nav a {
     background-color: #ffffff;
     display: flex;
     flex-direction: column;
+    box-sizing: border-box;
+    padding: 1.25rem;
+    gap: 1rem;
     height: 100%;
     border: 2px solid #b8b6b6;
     border-radius: 1rem;
@@ -304,6 +307,19 @@ nav a {
     transform: scale(1.1);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
     border-color: #9ca3af;
+}
+
+.article-card-media {
+    border-radius: 0.75rem;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.article-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex-grow: 1;
 }
 
 .article-card-image {


### PR DESCRIPTION
## Summary
- wrap article card media and content in dedicated containers so the layout can be adjusted without changing card size
- add internal padding and spacing styles to article cards to inset the image and text from the border

## Testing
- npm run lint *(fails: `next` command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d9ce0aec832da2cc60d625f0264a