### PR TITLE
Enhance podcasts page with cards and admin controls

### DIFF
--- a/components/PodcastCard.js
+++ b/components/PodcastCard.js
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+
+const FALLBACK_IMAGE = 'https://placehold.co/600x400?text=Podcast';
+
+function formatDate(dateString) {
+  if (!dateString) {
+    return '';
+  }
+
+  const parsed = new Date(dateString);
+  if (Number.isNaN(parsed.getTime())) {
+    return dateString;
+  }
+
+  return parsed.toLocaleDateString('fr-CA', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function PodcastCard({ podcast, isAdmin = false, onDelete }) {
+  const { id, title, image, date, slug } = podcast;
+  const coverImage = image || FALLBACK_IMAGE;
+
+  return (
+    <article className="article-card flex h-full max-w-md flex-col overflow-hidden rounded-2xl shadow-md">
+      <Link href={`/podcasts/${slug}`} className="flex flex-col flex-grow">
+        <div className="article-card-media">
+          <img src={coverImage} alt={title} className="article-card-image" />
+        </div>
+        <div className="article-card-content flex flex-grow flex-col">
+          <h3 className="mb-1 text-2xl font-bold leading-snug text-black">{title}</h3>
+          {date && <p className="mb-4 text-sm text-gray-500">{formatDate(date)}</p>}
+        </div>
+      </Link>
+      {isAdmin && (
+        <div className="border-t border-gray-200 bg-gray-50 p-4">
+          <button
+            type="button"
+            onClick={() => onDelete?.(id)}
+            className="w-full rounded bg-red-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-700"
+          >
+            Supprimer le podcast
+          </button>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/lib/podcastDatabase.js
+++ b/lib/podcastDatabase.js
@@ -12,6 +12,11 @@ function readPodcastsFile() {
   }
 }
 
+function writePodcastsFile(podcasts) {
+  fs.writeFileSync(podcastsFile, JSON.stringify(podcasts, null, 2));
+  return podcasts;
+}
+
 export function getPodcasts() {
   return readPodcastsFile();
 }
@@ -23,6 +28,19 @@ export function getPodcastBySlug(slug) {
 export function addPodcast(podcast) {
   const podcasts = readPodcastsFile();
   podcasts.push(podcast);
-  fs.writeFileSync(podcastsFile, JSON.stringify(podcasts, null, 2));
+  writePodcastsFile(podcasts);
   return podcast;
+}
+
+export function deletePodcastById(id) {
+  const podcasts = readPodcastsFile();
+  const index = podcasts.findIndex((podcast) => podcast.id === id);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const [removedPodcast] = podcasts.splice(index, 1);
+  writePodcastsFile(podcasts);
+  return removedPodcast;
 }

--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -37,6 +37,15 @@ export default function PodcastDetail({ podcast }) {
             <p className="text-sm uppercase tracking-wide text-gray-500">{displayDate}</p>
             <h1 className="text-3xl font-semibold">{podcast.title}</h1>
           </header>
+          {podcast.image && (
+            <div className="overflow-hidden rounded-lg">
+              <img
+                src={podcast.image}
+                alt={podcast.title}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          )}
           <div className="aspect-video w-full">
             <video
               src={podcast.video}


### PR DESCRIPTION
## Summary
- add a reusable podcast card component with article-style layout and admin delete action
- allow admins to upload cover images alongside podcast videos and display them on the detail page
- extend the podcasts API, hook, and page to support image storage, deletion, and refreshed card grid

## Testing
- npm run lint *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a357559c832db580fb3173ca3ff1