### PR TITLE
Add podcast bios and align detail page layout

### DIFF
--- a/components/PodcastCard.js
+++ b/components/PodcastCard.js
@@ -20,8 +20,11 @@ function formatDate(dateString) {
 }
 
 export default function PodcastCard({ podcast, isAdmin = false, onDelete }) {
-  const { id, title, image, date, slug } = podcast;
+  const { id, title, image, date, slug, bio, description, content } = podcast;
   const coverImage = image || FALLBACK_IMAGE;
+  const rawBio = bio || description || content || '';
+  const plainBio = rawBio ? rawBio.replace(/<[^>]+>/g, '') : '';
+  const excerpt = plainBio.length > 200 ? `${plainBio.slice(0, 200)}...` : plainBio;
 
   return (
     <article className="article-card flex h-full max-w-md flex-col overflow-hidden rounded-2xl shadow-md">
@@ -32,6 +35,7 @@ export default function PodcastCard({ podcast, isAdmin = false, onDelete }) {
         <div className="article-card-content flex flex-grow flex-col">
           <h3 className="mb-1 text-2xl font-bold leading-snug text-black">{title}</h3>
           {date && <p className="mb-4 text-sm text-gray-500">{formatDate(date)}</p>}
+          <p className="text-base text-gray-600 flex-grow">{excerpt}</p>
         </div>
       </Link>
       {isAdmin && (

--- a/hooks/usePodcasts.js
+++ b/hooks/usePodcasts.js
@@ -44,7 +44,7 @@ export default function usePodcasts() {
       reader.readAsDataURL(file);
     });
 
-  const addPodcast = async ({ title, date, video, image }) => {
+  const addPodcast = async ({ title, date, video, image, bio }) => {
     try {
       if (!video) {
         throw new Error('A video file must be provided');
@@ -65,6 +65,7 @@ export default function usePodcasts() {
         body: JSON.stringify({
           title,
           date,
+          bio,
           videoDataUrl,
           originalName: video.name,
           imageDataUrl,

--- a/pages/api/podcasts.js
+++ b/pages/api/podcasts.js
@@ -94,6 +94,7 @@ export default function handler(req, res) {
     const {
       title,
       date,
+      bio,
       videoDataUrl,
       originalName,
       imageDataUrl,
@@ -130,6 +131,7 @@ export default function handler(req, res) {
       image: storedImagePath,
       slug: createSlug(title, podcasts),
       createdAt: new Date().toISOString(),
+      bio: typeof bio === 'string' ? bio.trim() : '',
     };
 
     addPodcast(podcast);

--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -1,8 +1,11 @@
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import Navbar from '../../components/Navbar';
 import { getPodcastBySlug } from '../../lib/podcastDatabase';
 
 export default function PodcastDetail({ podcast }) {
+  const router = useRouter();
+
   if (!podcast) {
     return (
       <>
@@ -25,36 +28,44 @@ export default function PodcastDetail({ podcast }) {
       })
     : '';
 
+  const handleBack = () => {
+    router.back();
+  };
+
   return (
     <>
       <Head>
         <title>{podcast.title}</title>
       </Head>
       <Navbar />
-      <main className="mx-auto max-w-4xl p-4">
-        <article className="space-y-6 rounded-lg bg-white p-6 shadow">
-          <header>
-            <p className="text-sm uppercase tracking-wide text-gray-500">{displayDate}</p>
-            <h1 className="text-3xl font-semibold">{podcast.title}</h1>
-          </header>
-          {podcast.image && (
-            <div className="overflow-hidden rounded-lg">
-              <img
-                src={podcast.image}
-                alt={podcast.title}
-                className="h-full w-full object-cover"
-              />
-            </div>
+      <main className="article-page article-box">
+        <button type="button" onClick={handleBack} className="back-button">
+          ← Arrière
+        </button>
+        <header className="mb-6 text-center">
+          <h1 className="mb-2 text-3xl font-semibold">{podcast.title}</h1>
+          {displayDate && <p className="text-sm text-gray-600">{displayDate}</p>}
+          {podcast.bio && (
+            <p className="mt-4 text-base text-gray-700">{podcast.bio}</p>
           )}
-          <div className="aspect-video w-full">
-            <video
-              src={podcast.video}
-              controls
-              autoPlay
-              className="h-full w-full rounded-lg bg-black"
+        </header>
+        {podcast.image && (
+          <div className="mb-6 overflow-hidden rounded-lg">
+            <img
+              src={podcast.image}
+              alt={podcast.title}
+              className="h-full w-full object-cover"
             />
           </div>
-        </article>
+        )}
+        <div className="aspect-video w-full">
+          <video
+            src={podcast.video}
+            controls
+            autoPlay
+            className="h-full w-full rounded-lg bg-black"
+          />
+        </div>
       </main>
     </>
   );

--- a/pages/podcasts/index.js
+++ b/pages/podcasts/index.js
@@ -11,6 +11,7 @@ export default function PodcastsPage() {
   const [date, setDate] = useState('');
   const [videoFile, setVideoFile] = useState(null);
   const [imageFile, setImageFile] = useState(null);
+  const [bio, setBio] = useState('');
 
   useEffect(() => {
     setIsAdmin(document.cookie.includes('admin-auth=true'));
@@ -20,9 +21,10 @@ export default function PodcastsPage() {
     event.preventDefault();
     if (!title || !date || !videoFile || !imageFile) return;
 
-    await addPodcast({ title, date, video: videoFile, image: imageFile });
+    await addPodcast({ title, date, bio, video: videoFile, image: imageFile });
     setTitle('');
     setDate('');
+    setBio('');
     setVideoFile(null);
     setImageFile(null);
     event.target.reset();
@@ -87,6 +89,22 @@ export default function PodcastsPage() {
                   className="w-full rounded border border-gray-300 p-2"
                   required
                 />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium" htmlFor="bio">
+                  Courte bio
+                </label>
+                <textarea
+                  id="bio"
+                  value={bio}
+                  onChange={(event) => setBio(event.target.value)}
+                  className="w-full rounded border border-gray-300 p-2"
+                  placeholder="Ajoutez une courte description du podcast"
+                  rows={4}
+                />
+                <p className="mt-1 text-sm text-gray-500">
+                  Cette bio sera affichée sur la carte du podcast et sur la page détaillée.
+                </p>
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium" htmlFor="video">


### PR DESCRIPTION
## Summary
- allow admins to capture a short bio when creating a podcast and persist it with the entry
- display the bio excerpt on podcast cards and under the title on the podcast detail page with an article-style layout
- reuse the article page styling with a back button and adjusted metadata presentation on podcast detail pages

## Testing
- npm run lint *(fails: next binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5aa401624832d9446fe9a9cd1d266