### PR TITLE
Increase podcast API body size limit

### DIFF
--- a/pages/api/podcasts.js
+++ b/pages/api/podcasts.js
@@ -160,3 +160,15 @@ export default function handler(req, res) {
   const podcasts = getPodcasts();
   res.status(200).json(podcasts);
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      // Podcasts include base64-encoded video and image payloads which easily
+      // exceed Next.js' default 1MB body size limit. Increasing the limit
+      // ensures the request body is fully parsed instead of being rejected
+      // before we can persist the podcast to disk.
+      sizeLimit: '200mb',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- raise the API body parser size limit for podcast uploads to accommodate base64 video and image payloads
- document the reasoning inline so future maintainers know why the larger limit is needed

## Testing
- `npm run lint` *(fails: next binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b1205ad0832da36108ac8d19430e