### PR TITLE
Move podcasts data to MongoDB

### DIFF
--- a/lib/podcastDatabase.js
+++ b/lib/podcastDatabase.js
@@ -1,46 +1,95 @@
-import fs from 'fs';
-import path from 'path';
+import { MongoClient, ObjectId } from 'mongodb';
 
-const podcastsFile = path.join(process.cwd(), 'data', 'podcasts.json');
+let cachedClientPromise = null;
 
-function readPodcastsFile() {
-  try {
-    const data = fs.readFileSync(podcastsFile, 'utf8');
-    return JSON.parse(data);
-  } catch (err) {
-    return [];
+async function getCollection() {
+  const uri = process.env.MONGODB_URI;
+
+  if (!uri) {
+    throw new Error('MONGODB_URI not configured');
   }
+
+  if (!cachedClientPromise) {
+    if (!globalThis._podcastClientPromise) {
+      const client = new MongoClient(uri);
+      globalThis._podcastClientPromise = client.connect();
+    }
+
+    cachedClientPromise = globalThis._podcastClientPromise;
+  }
+
+  const client = await cachedClientPromise;
+  return client.db().collection('podcasts');
 }
 
-function writePodcastsFile(podcasts) {
-  fs.writeFileSync(podcastsFile, JSON.stringify(podcasts, null, 2));
-  return podcasts;
-}
-
-export function getPodcasts() {
-  return readPodcastsFile();
-}
-
-export function getPodcastBySlug(slug) {
-  return readPodcastsFile().find((podcast) => podcast.slug === slug) || null;
-}
-
-export function addPodcast(podcast) {
-  const podcasts = readPodcastsFile();
-  podcasts.push(podcast);
-  writePodcastsFile(podcasts);
-  return podcast;
-}
-
-export function deletePodcastById(id) {
-  const podcasts = readPodcastsFile();
-  const index = podcasts.findIndex((podcast) => podcast.id === id);
-
-  if (index === -1) {
+function normalizePodcast(doc) {
+  if (!doc) {
     return null;
   }
 
-  const [removedPodcast] = podcasts.splice(index, 1);
-  writePodcastsFile(podcasts);
-  return removedPodcast;
+  const { _id, ...rest } = doc;
+
+  return {
+    ...rest,
+    id: _id ? _id.toString() : rest.id ?? null,
+  };
+}
+
+export async function getPodcasts() {
+  const collection = await getCollection();
+  const docs = await collection
+    .find({})
+    .sort({ createdAt: -1, _id: -1 })
+    .toArray();
+
+  return docs.map((doc) => normalizePodcast(doc));
+}
+
+export async function getPodcastBySlug(slug) {
+  if (!slug) {
+    return null;
+  }
+
+  const collection = await getCollection();
+  const doc = await collection.findOne({ slug });
+  return normalizePodcast(doc);
+}
+
+export async function addPodcast(podcast) {
+  const collection = await getCollection();
+
+  const payload = {
+    title: podcast.title,
+    date: podcast.date,
+    video: podcast.video,
+    image: podcast.image,
+    slug: podcast.slug,
+    bio: podcast.bio || '',
+    createdAt: podcast.createdAt || new Date().toISOString(),
+  };
+
+  const result = await collection.insertOne(payload);
+
+  return {
+    ...payload,
+    id: result.insertedId.toString(),
+  };
+}
+
+export async function deletePodcastById(id) {
+  if (!id) {
+    return null;
+  }
+
+  const collection = await getCollection();
+
+  let objectId;
+  try {
+    objectId = new ObjectId(id);
+  } catch (err) {
+    return null;
+  }
+
+  const result = await collection.findOneAndDelete({ _id: objectId });
+  return normalizePodcast(result.value);
 }

--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -72,19 +72,28 @@ export default function PodcastDetail({ podcast }) {
 }
 
 export async function getServerSideProps({ params }) {
-  const podcast = getPodcastBySlug(params.slug);
+  try {
+    const podcast = await getPodcastBySlug(params.slug);
 
-  if (!podcast) {
+    if (!podcast) {
+      return {
+        props: {
+          podcast: null,
+        },
+      };
+    }
+
+    return {
+      props: {
+        podcast,
+      },
+    };
+  } catch (error) {
+    console.error('Failed to fetch podcast for page:', error);
     return {
       props: {
         podcast: null,
       },
     };
   }
-
-  return {
-    props: {
-      podcast,
-    },
-  };
 }


### PR DESCRIPTION
## Summary
- replace the filesystem-based podcast helper with a MongoDB-backed implementation that reuses a cached client
- update the podcasts API route to persist uploads in the database, ensure unique slugs, and surface failures cleanly
- adjust the podcast detail page to read data from the database with defensive error handling

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b2e6c720832d850e2b8ba63e7a56