### PR TITLE
Center podcast video on detail page

### DIFF
--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -49,22 +49,15 @@ export default function PodcastDetail({ podcast }) {
             <p className="mt-4 text-base text-gray-700">{podcast.bio}</p>
           )}
         </header>
-        {podcast.image && (
-          <div className="mb-6 overflow-hidden rounded-lg">
-            <img
-              src={podcast.image}
-              alt={podcast.title}
-              className="h-full w-full object-cover"
+        <div className="mx-auto mt-6 w-full max-w-3xl">
+          <div className="aspect-video w-full">
+            <video
+              src={podcast.video}
+              controls
+              autoPlay
+              className="h-full w-full rounded-lg bg-black"
             />
           </div>
-        )}
-        <div className="aspect-video w-full">
-          <video
-            src={podcast.video}
-            controls
-            autoPlay
-            className="h-full w-full rounded-lg bg-black"
-          />
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- remove the cover image display from the podcast detail view
- center the embedded video by constraining it within a centered container

## Testing
- npm run lint *(fails: next command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b4a0b6a4832d8522494ed84a9f3a