### PR TITLE
Fix podcast video alignment

### DIFF
--- a/pages/podcasts/[slug].js
+++ b/pages/podcasts/[slug].js
@@ -49,15 +49,13 @@ export default function PodcastDetail({ podcast }) {
             <p className="mt-4 text-base text-gray-700">{podcast.bio}</p>
           )}
         </header>
-        <div className="mx-auto mt-6 w-full max-w-3xl">
-          <div className="aspect-video w-full">
-            <video
-              src={podcast.video}
-              controls
-              autoPlay
-              className="h-full w-full rounded-lg bg-black"
-            />
-          </div>
+        <div className="podcast-video-container">
+          <video
+            src={podcast.video}
+            controls
+            autoPlay
+            className="podcast-video-player"
+          />
         </div>
       </main>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -666,6 +666,22 @@ button[type="submit"]:hover {
     margin-bottom: 1rem;
 }
 
+.podcast-video-container {
+    margin: 2rem auto 0;
+    max-width: 800px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.podcast-video-player {
+    width: 100%;
+    max-width: 720px;
+    border-radius: 0.75rem;
+    background-color: #000;
+    display: block;
+}
+
 .article-box {
     border: 1px solid #b8b6b6;
     padding: 3rem;


### PR DESCRIPTION
## Summary
- update the podcast detail page markup to use a dedicated wrapper around the video player
- add global styles to center the podcast video and ensure it scales to the content width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a4fb26b8832d848971694b5faea6