### PR TITLE
Store events in MongoDB

### DIFF
--- a/lib/eventDatabase.js
+++ b/lib/eventDatabase.js
@@ -1,20 +1,82 @@
-import fs from 'fs';
-import path from 'path';
+import { MongoClient, ObjectId } from 'mongodb';
 
-const eventsFile = path.join(process.cwd(), 'data', 'events.json');
+let cachedClientPromise = null;
 
-export function getEvents() {
-  try {
-    const data = fs.readFileSync(eventsFile, 'utf8');
-    return JSON.parse(data);
-  } catch (err) {
-    return [];
+async function getCollection() {
+  const uri = process.env.MONGODB_URI;
+
+  if (!uri) {
+    throw new Error('MONGODB_URI not configured');
   }
+
+  if (!cachedClientPromise) {
+    if (!globalThis._eventClientPromise) {
+      const client = new MongoClient(uri);
+      globalThis._eventClientPromise = client.connect();
+    }
+
+    cachedClientPromise = globalThis._eventClientPromise;
+  }
+
+  const client = await cachedClientPromise;
+  return client.db().collection('events');
 }
 
-export function addEvent(event) {
-  const events = getEvents();
-  events.push(event);
-  fs.writeFileSync(eventsFile, JSON.stringify(events, null, 2));
-  return events;
+function normalizeEvent(doc) {
+  if (!doc) {
+    return null;
+  }
+
+  const { _id, ...rest } = doc;
+
+  return {
+    ...rest,
+    id: _id ? _id.toString() : rest.id ?? null,
+  };
+}
+
+export async function getEvents() {
+  const collection = await getCollection();
+  const docs = await collection
+    .find({})
+    .sort({ date: 1, createdAt: -1, _id: -1 })
+    .toArray();
+
+  return docs.map((doc) => normalizeEvent(doc));
+}
+
+export async function getEventById(id) {
+  if (!id) {
+    return null;
+  }
+
+  const collection = await getCollection();
+
+  let objectId;
+  try {
+    objectId = new ObjectId(id);
+  } catch (err) {
+    return null;
+  }
+
+  const doc = await collection.findOne({ _id: objectId });
+  return normalizeEvent(doc);
+}
+
+export async function addEvent(event) {
+  const collection = await getCollection();
+
+  const payload = {
+    title: event.title,
+    bio: event.bio,
+    date: event.date,
+    createdAt: event.createdAt || new Date().toISOString(),
+  };
+
+  const result = await collection.insertOne(payload);
+
+  return {
+    ...payload,
+    id: result.insertedId.toString(),
+  };
 }

--- a/pages/api/events.js
+++ b/pages/api/events.js
@@ -1,15 +1,32 @@
-import { getEvents, addEvent } from '../../lib/eventDatabase';
+import { addEvent, getEvents } from '../../lib/eventDatabase';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method === 'POST') {
-    const { title, bio, date } = req.body;
+    const { title, bio, date } = req.body || {};
+
     if (!title || !bio || !date) {
       return res.status(400).json({ error: 'title, bio and date are required' });
     }
-    addEvent({ id: Date.now().toString(), title, bio, date });
-    return res.status(201).json({ ok: true });
+
+    try {
+      const created = await addEvent({ title, bio, date });
+      return res.status(201).json(created);
+    } catch (err) {
+      console.error('Failed to add event', err);
+      return res.status(500).json({ error: 'Failed to create event' });
+    }
   }
 
-  const events = getEvents();
-  res.status(200).json(events);
+  if (req.method === 'GET') {
+    try {
+      const events = await getEvents();
+      return res.status(200).json(events);
+    } catch (err) {
+      console.error('Failed to fetch events', err);
+      return res.status(500).json({ error: 'Failed to fetch events' });
+    }
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 }


### PR DESCRIPTION
## Summary
- replace the events file helper with a MongoDB-backed implementation and expose a getter for single events
- update the events API route to persist and fetch events through the database with better error handling

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cdb5f348832d9c9b3d74eaa51e9c