### PR TITLE
Ensure event list updates with calendar month selection

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -193,6 +193,7 @@ export default function Evenements() {
                     className="calendar"
                     month={visibleMonthDate}
                     onMonthChange={updateVisibleMonth}
+                    onMonthSelect={updateVisibleMonth}
                     onChange={updateVisibleMonth}
                     size="lg"
                     renderDay={(currentDate) => {


### PR DESCRIPTION
## Summary
- keep the events list in sync with the calendar by updating month state when a month is chosen from the header

## Testing
- npm run lint *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d1943c48832d9edbac5f69c78715