### PR TITLE
Make article page container white

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -687,7 +687,7 @@ button[type="submit"]:hover {
     padding: 3rem;
     border-radius: 0.25rem;
     margin: 2rem auto;
-    background-color: #e6dede;
+    background-color: #ffffff;
     max-width: 800px;
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- change the article page container background color to white so the content is not transparent

## Testing
- npm run dev *(fails: next command not found in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d92f80e4832daf1fc5319018577c