### PR TITLE
Improve contact form email delivery

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,17 @@
+# Email configuration used by the contact form API route.
+#
+# Provide either a fully qualified SMTP connection string in EMAIL_SERVER
+# (for example: smtp://user:pass@smtp.example.com:587) or configure the
+# host/port credentials individually. EMAIL_TO defaults to EMAIL_USER when
+# not provided.
+
+# EMAIL_SERVER=
+
+# EMAIL_HOST=smtp.example.com
+# EMAIL_PORT=587
+# EMAIL_SECURE=false
+# EMAIL_USER=your-smtp-username
+# EMAIL_PASS=your-smtp-password
+
+# EMAIL_FROM=contact@example.com
+# EMAIL_TO=recipient@example.com

--- a/components/ContactCard.js
+++ b/components/ContactCard.js
@@ -7,6 +7,8 @@ export default function ContactCard({ leftContent, rightContent }) {
         objet: '',
         message: ''
     });
+    const [status, setStatus] = useState({ type: null, message: '' });
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const handleChange = (e) => {
         const { name, value } = e.target;
@@ -18,6 +20,8 @@ export default function ContactCard({ leftContent, rightContent }) {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+        setIsSubmitting(true);
+        setStatus({ type: null, message: '' });
         try {
             const response = await fetch('/api/send-email', {
                 method: 'POST',
@@ -26,14 +30,17 @@ export default function ContactCard({ leftContent, rightContent }) {
                 },
                 body: JSON.stringify(formData)
             });
-            if (response.ok) {
-                alert('Email sent successfully');
-            } else {
-                alert('Failed to send email');
+            const data = await response.json().catch(() => ({ message: 'Une erreur est survenue.' }));
+            if (!response.ok) {
+                throw new Error(data?.message || 'Échec de l\'envoi du courriel.');
             }
+            setFormData({ nom: '', email: '', objet: '', message: '' });
+            setStatus({ type: 'success', message: data?.message || 'Votre message a été envoyé avec succès.' });
         } catch (error) {
             console.error('Error sending email:', error);
-            alert('An error occurred while sending the email');
+            setStatus({ type: 'error', message: error.message || 'Une erreur est survenue lors de l\'envoi du courriel.' });
+        } finally {
+            setIsSubmitting(false);
         }
     };
 
@@ -57,6 +64,7 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 onChange={handleChange}
                                 className="w-full p-2 border rounded"
                                 placeholder="Votre nom"
+                                required
                             />
                         </div>
                         <div className="mb-4 flex flex-col items-center">
@@ -69,6 +77,7 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 onChange={handleChange}
                                 className="w-full p-2 border rounded"
                                 placeholder="Votre Courriel"
+                                required
                             />
                         </div>
                         <div className="mb-4 flex flex-col items-center">
@@ -81,6 +90,7 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 onChange={handleChange}
                                 className="w-full p-2 border rounded"
                                 placeholder="Objet de votre message"
+                                required
                             />
                         </div>
                         <div className="mb-4 flex flex-col items-center">
@@ -92,9 +102,25 @@ export default function ContactCard({ leftContent, rightContent }) {
                                 onChange={handleChange}
                                 className="w-full p-2 border rounded"
                                 placeholder="Votre message"
+                                rows="4"
+                                required
                             />
                         </div>
-                        <button type="submit" className="bg-blue-500 text-white p-2 rounded">Envoyer</button>
+                        <button
+                            type="submit"
+                            className="bg-blue-500 text-white p-2 rounded disabled:opacity-60 disabled:cursor-not-allowed"
+                            disabled={isSubmitting}
+                        >
+                            {isSubmitting ? 'Envoi...' : 'Envoyer'}
+                        </button>
+                        {status.message && (
+                            <p
+                                className={`mt-4 text-center ${status.type === 'success' ? 'text-green-600' : 'text-red-600'}`}
+                                role="status"
+                            >
+                                {status.message}
+                            </p>
+                        )}
                     </form>
                 </div>
             </div>

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -1,0 +1,82 @@
+import nodemailer from 'nodemailer';
+
+let transporterPromise;
+
+const REQUIRED_ENV_VARS = ['EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_USER', 'EMAIL_PASS'];
+
+function hasSmtpConfig() {
+    return REQUIRED_ENV_VARS.every((key) => process.env[key]);
+}
+
+async function createTransporter() {
+    if (process.env.EMAIL_SERVER) {
+        return nodemailer.createTransport(process.env.EMAIL_SERVER);
+    }
+
+    if (!hasSmtpConfig()) {
+        throw new Error(
+            'Email service is not configured. Please provide EMAIL_SERVER or EMAIL_HOST, EMAIL_PORT, EMAIL_USER and EMAIL_PASS environment variables.'
+        );
+    }
+
+    return nodemailer.createTransport({
+        host: process.env.EMAIL_HOST,
+        port: Number(process.env.EMAIL_PORT),
+        secure: process.env.EMAIL_SECURE === 'true' || Number(process.env.EMAIL_PORT) === 465,
+        auth: {
+            user: process.env.EMAIL_USER,
+            pass: process.env.EMAIL_PASS
+        }
+    });
+}
+
+async function getTransporter() {
+    if (!transporterPromise) {
+        transporterPromise = createTransporter().then(async (transporter) => {
+            try {
+                await transporter.verify();
+            } catch (error) {
+                console.warn('Unable to verify email transporter:', error.message);
+            }
+            return transporter;
+        });
+    }
+    return transporterPromise;
+}
+
+export async function sendContactEmail({ nom, email, objet, message }) {
+    const transporter = await getTransporter();
+    const to = process.env.EMAIL_TO || process.env.EMAIL_USER;
+
+    if (!to) {
+        throw new Error('Destination email address is not configured. Please set EMAIL_TO or EMAIL_USER.');
+    }
+
+    return transporter.sendMail({
+        from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
+        to,
+        subject: `Contact Form: ${objet}`,
+        text: `Nom: ${nom}\nEmail: ${email}\n\n${message}`,
+        replyTo: email
+    });
+}
+
+export function validateEmailConfiguration() {
+    try {
+        if (process.env.EMAIL_SERVER) {
+            return null;
+        }
+
+        if (!hasSmtpConfig()) {
+            return 'Email service is not configured. Please set EMAIL_SERVER or the SMTP variables.';
+        }
+
+        if (!process.env.EMAIL_TO && !process.env.EMAIL_USER) {
+            return 'Email recipient is not configured. Please set EMAIL_TO or EMAIL_USER.';
+        }
+
+        return null;
+    } catch (error) {
+        return error.message;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable mailer helper that validates SMTP configuration before sending
- update the contact API route to use the helper and return localized status messages
- enhance the contact form UX with inline status feedback, validation, and env documentation

## Testing
- npm run lint *(fails: `next` binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e16495d8832d9c0c63ab85480506