### PR TITLE
Handle missing email configuration gracefully

### DIFF
--- a/components/ContactCard.js
+++ b/components/ContactCard.js
@@ -31,9 +31,15 @@ export default function ContactCard({ leftContent, rightContent }) {
                 body: JSON.stringify(formData)
             });
             const data = await response.json().catch(() => ({ message: 'Une erreur est survenue.' }));
+
             if (!response.ok) {
-                throw new Error(data?.message || 'Échec de l\'envoi du courriel.');
+                setStatus({
+                    type: 'error',
+                    message: data?.message || 'Échec de l\'envoi du courriel.'
+                });
+                return;
             }
+
             setFormData({ nom: '', email: '', objet: '', message: '' });
             setStatus({ type: 'success', message: data?.message || 'Votre message a été envoyé avec succès.' });
         } catch (error) {


### PR DESCRIPTION
## Summary
- avoid throwing an exception when the email API returns an error
- surface the returned error message in the contact form status instead

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6eb582390832d9b2fb8a31b6097ed