### PR TITLE
Handle SMTP auth errors with clearer guidance

### DIFF
--- a/docs/email-configuration.md
+++ b/docs/email-configuration.md
@@ -19,6 +19,7 @@ CONTACT_EMAIL_PASS="<GMAIL_APP_PASSWORD>"
 with regular account passwords. After updating the environment variables, restart
 the Next.js server so it loads the new credentials.
 
-If transporter verification fails, double-check that the app password is
-correct, SMTP access is enabled for the Gmail account, and the host/port values
-match your email provider.
+If transporter verification fails or you see an authentication error (`EAUTH`,
+`535 5.7.8 Username and Password not accepted`), double-check that the app
+password is correct, SMTP access is enabled for the Gmail account, and the
+host/port values match your email provider.

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -25,6 +25,15 @@ export default async function handler(req, res) {
         res.status(200).json({ message: 'Votre message a été envoyé avec succès.' });
     } catch (error) {
         console.error('Error sending email:', error);
+
+        if (error?.code === 'EAUTH' || error?.responseCode === 535) {
+            res.status(500).json({
+                message:
+                    'La connexion au serveur de courriel a échoué. Vérifiez le nom d’utilisateur et le mot de passe d’application Gmail configurés.'
+            });
+            return;
+        }
+
         res.status(500).json({ message: "Impossible d'envoyer le courriel pour le moment." });
     }
 }


### PR DESCRIPTION
## Summary
- return a more informative error message when Gmail authentication fails in the contact form API
- document the Gmail app password requirement in the email configuration guide when a 535 error appears

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dac0ed893c832dba3b35410a94762c