### PR TITLE
Adjust article author layout

### DIFF
--- a/pages/articles/[id].js
+++ b/pages/articles/[id].js
@@ -64,13 +64,13 @@ export default function Article() {
           <Image
             src={currentArticle.authorImage}
             alt={currentArticle.author}
-            width={40}
-            height={40}
+            width={60}
+            height={60}
             className="author-image"
           />
-          <div className="ml-2">
-            <p className="text-sm font-semibold">{currentArticle.author}</p>
-            <p className="text-sm text-gray-600">{currentArticle.date}</p>
+          <div className="ml-2 author-details">
+            <p className="text-sm text-gray-600 author-date">{currentArticle.date}</p>
+            <p className="text-sm font-semibold author-name">{currentArticle.author}</p>
           </div>
         </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,8 +20,8 @@ main {
 }
 
 .author-image {
-    width: 40px;
-    height: 40px;
+    width: 60px;
+    height: 60px;
     border-radius: 50%;
     object-fit: cover;
 }
@@ -38,9 +38,19 @@ main {
     color: #718096;
 }
 
-.flex.items-center .ml-2 {
+.author-details {
     display: flex;
     flex-direction: column;
+    line-height: 1.1;
+    gap: 0.2rem;
+}
+
+.author-date {
+    margin-bottom: 0.1rem;
+}
+
+.author-name {
+    margin-top: 0.1rem;
 }
 
 .banner {


### PR DESCRIPTION
## Summary
- enlarge the article author avatar and reposition the metadata stack
- tighten spacing between the author name and date for a closer grouping

## Testing
- `npm run dev` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68dac5973800832d95e3901c0213cd71