### PR TITLE
Add font-bold utility class for active navbar link

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -214,6 +214,10 @@ nav a {
     font-weight: 600;
 }
 
+.font-bold {
+    font-weight: 700;
+}
+
 .flex {
     display: flex;
 }


### PR DESCRIPTION
## Summary
- add a reusable `.font-bold` utility class to support bold text styling across the site
- ensure the navbar can highlight the current page link by applying the bold style

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad60c95f4832da492422982dc09cb