### PR TITLE
refactor: centralize MongoDB connection

### DIFF
--- a/docs/database-configuration.md
+++ b/docs/database-configuration.md
@@ -1,0 +1,17 @@
+# Database configuration
+
+The application connects to MongoDB using two environment variables that must be
+set in both local development and deployed environments:
+
+```bash
+MONGODB_URI="mongodb+srv://<user>:<password>@<cluster>/"
+MONGODB_DB_NAME="<database-name>"
+```
+
+`MONGODB_URI` provides the connection string for your cluster while
+`MONGODB_DB_NAME` specifies the exact database to use. Configure the same values
+in `.env.local` and in your hosting provider so every environment points at the
+same MongoDB database.
+
+Restart the Next.js server after updating either variable to ensure the new
+configuration is loaded.

--- a/lib/eventDatabase.js
+++ b/lib/eventDatabase.js
@@ -1,25 +1,9 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClientPromise = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from './mongoClient';
 
 async function getCollection() {
-  const uri = process.env.MONGODB_URI;
-
-  if (!uri) {
-    throw new Error('MONGODB_URI not configured');
-  }
-
-  if (!cachedClientPromise) {
-    if (!globalThis._eventClientPromise) {
-      const client = new MongoClient(uri);
-      globalThis._eventClientPromise = client.connect();
-    }
-
-    cachedClientPromise = globalThis._eventClientPromise;
-  }
-
-  const client = await cachedClientPromise;
-  return client.db().collection('events');
+  const db = await getMongoDb();
+  return db.collection('events');
 }
 
 function normalizeEvent(doc) {

--- a/lib/mongoClient.js
+++ b/lib/mongoClient.js
@@ -1,0 +1,34 @@
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI;
+const dbName = process.env.MONGODB_DB_NAME;
+
+if (!uri) {
+  throw new Error('MONGODB_URI not configured');
+}
+
+if (!dbName) {
+  throw new Error('MONGODB_DB_NAME not configured');
+}
+
+let cachedClientPromise = null;
+let cachedDb = null;
+
+export default async function getMongoDb() {
+  if (cachedDb) {
+    return cachedDb;
+  }
+
+  if (!cachedClientPromise) {
+    if (!globalThis._mongoClientPromise) {
+      const client = new MongoClient(uri);
+      globalThis._mongoClientPromise = client.connect();
+    }
+
+    cachedClientPromise = globalThis._mongoClientPromise;
+  }
+
+  const client = await cachedClientPromise;
+  cachedDb = client.db(dbName);
+  return cachedDb;
+}

--- a/lib/podcastDatabase.js
+++ b/lib/podcastDatabase.js
@@ -1,25 +1,9 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClientPromise = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from './mongoClient';
 
 async function getCollection() {
-  const uri = process.env.MONGODB_URI;
-
-  if (!uri) {
-    throw new Error('MONGODB_URI not configured');
-  }
-
-  if (!cachedClientPromise) {
-    if (!globalThis._podcastClientPromise) {
-      const client = new MongoClient(uri);
-      globalThis._podcastClientPromise = client.connect();
-    }
-
-    cachedClientPromise = globalThis._podcastClientPromise;
-  }
-
-  const client = await cachedClientPromise;
-  return client.db().collection('podcasts');
+  const db = await getMongoDb();
+  return db.collection('podcasts');
 }
 
 function normalizePodcast(doc) {

--- a/pages/api/articles.js
+++ b/pages/api/articles.js
@@ -1,6 +1,5 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClient = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from '../../lib/mongoClient';
 
 /**
  * API route to manage blog articles.
@@ -8,17 +7,7 @@ let cachedClient = null;
  */
 export default async function handler(req, res) {
   try {
-    const uri = process.env.MONGODB_URI;
-    if (!uri) {
-      return res.status(500).json({ error: 'MONGODB_URI not configured' });
-    }
-
-    if (!cachedClient) {
-      const client = new MongoClient(uri);
-      cachedClient = await client.connect();
-    }
-
-    const db = cachedClient.db();
+    const db = await getMongoDb();
     const collection = db.collection('articles');
 
     if (req.method === 'POST') {

--- a/pages/api/content.js
+++ b/pages/api/content.js
@@ -1,20 +1,8 @@
-import { MongoClient } from 'mongodb';
-
-let cachedClient = null;
+import getMongoDb from '../../lib/mongoClient';
 
 export default async function handler(req, res) {
   try {
-    const uri = process.env.MONGODB_URI;
-    if (!uri) {
-      return res.status(500).json({ error: 'MONGODB_URI not configured' });
-    }
-
-    if (!cachedClient) {
-      const client = new MongoClient(uri);
-      cachedClient = await client.connect();
-    }
-
-    const db = cachedClient.db();
+    const db = await getMongoDb();
     const collection = db.collection('content');
 
     if (req.method === 'GET') {

--- a/pages/api/guide-sponsors.js
+++ b/pages/api/guide-sponsors.js
@@ -1,28 +1,18 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClient = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from '../../lib/mongoClient';
 
 /**
  * Retrieve sponsors for the Guide des Commanditaires page from the
  * `guide_sponsors` collection. Each document should contain
  * `{ image: string }` where the image is a base64-encoded data URL.
  *
- * This API route expects an environment variable `MONGODB_URI` to be
- * defined with the connection string to the database.
+ * This API route expects environment variables `MONGODB_URI` and
+ * `MONGODB_DB_NAME` to be defined with the connection string and
+ * database name.
  */
 export default async function handler(req, res) {
     try {
-        const uri = process.env.MONGODB_URI;
-        if (!uri) {
-            return res.status(500).json({ error: 'MONGODB_URI not configured' });
-        }
-
-        if (!cachedClient) {
-            const client = new MongoClient(uri);
-            cachedClient = await client.connect();
-        }
-
-        const db = cachedClient.db();
+        const db = await getMongoDb();
         const collection = db.collection('guide_sponsors');
 
         if (req.method === 'POST') {

--- a/pages/api/sponsors.js
+++ b/pages/api/sponsors.js
@@ -1,28 +1,18 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClient = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from '../../lib/mongoClient';
 
 /**
  * Retrieve sponsor logos for the home page carousel from the
  * `home_sponsors` collection. Each document should contain
  * `{ image: string }` where the image is a base64-encoded data URL.
  *
- * This API route expects an environment variable `MONGODB_URI` to be
- * defined with the connection string to the database.
+ * This API route expects environment variables `MONGODB_URI` and
+ * `MONGODB_DB_NAME` to be defined with the connection string and
+ * database name.
  */
 export default async function handler(req, res) {
     try {
-        const uri = process.env.MONGODB_URI;
-        if (!uri) {
-            return res.status(500).json({ error: 'MONGODB_URI not configured' });
-        }
-
-        if (!cachedClient) {
-            const client = new MongoClient(uri);
-            cachedClient = await client.connect();
-        }
-
-        const db = cachedClient.db();
+        const db = await getMongoDb();
         const collection = db.collection('home_sponsors');
 
         if (req.method === 'POST') {

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -1,26 +1,16 @@
-import { MongoClient, ObjectId } from 'mongodb';
-
-let cachedClient = null;
+import { ObjectId } from 'mongodb';
+import getMongoDb from '../../lib/mongoClient';
 
 /**
  * Retrieve or create users from the `users` collection.
  * Each document contains `{ title: string, name: string, profilePicture: string }`.
  *
- * Expects `MONGODB_URI` environment variable for connection string.
+ * Expects `MONGODB_URI` and `MONGODB_DB_NAME` environment variables for
+ * the connection string and database name.
  */
 export default async function handler(req, res) {
   try {
-    const uri = process.env.MONGODB_URI;
-    if (!uri) {
-      return res.status(500).json({ error: 'MONGODB_URI not configured' });
-    }
-
-    if (!cachedClient) {
-      const client = new MongoClient(uri);
-      cachedClient = await client.connect();
-    }
-
-    const db = cachedClient.db();
+    const db = await getMongoDb();
     const collection = db.collection('users');
 
     if (req.method === 'POST') {


### PR DESCRIPTION
## Summary
- add a shared MongoDB helper that caches the client and selects the configured database
- update database utilities and API routes to reuse the shared helper
- document the new MONGODB_DB_NAME environment variable for consistent configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3dc1e30c832da4a311ee988da68d